### PR TITLE
AMP-84891 added a note for cohort size difference between amplitude and TTD

### DIFF
--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -47,7 +47,7 @@ To sync your first cohort, follow these steps:
 
 ### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
-Amplitude reports a cohort sync as successful even if there are invalid IDs in the sync. As a result, the number of users in TheTradeDesk may be different than the number you have in Amplitude. If your sync contains duplicate IDs or a parsing error occurs, TheTradeDesk won't add those users.
+Amplitude reports a cohort sync as successful even if there are invalid IDs in the sync. As a result, the number of users in TheTradeDesk may be different than the number you have in Amplitude. If your sync contains duplicate IDs or a parsing error occurs, TheTradeDesk won't add those users.  The number of users that appears in TheTradeDesk is the number that was successfully imported from Amplitude.
 
 ### Use cases
 

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -45,7 +45,7 @@ To sync your first cohort, follow these steps:
 4. Choose the sync cadence.
 5. When finished, save your work.
 
-#### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
+### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
 We are showing our sync as successful even if there are invalid IDs for the integration with the TradeDesk. So, the number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
 

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -47,7 +47,7 @@ To sync your first cohort, follow these steps:
 
 ### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
-We are showing our sync as successful even if there are invalid IDs for the integration with the TradeDesk. So, the number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
+Amplitude are showing our sync as successful even if there are invalid IDs for the integration with the TradeDesk. The number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
 
 ### Use cases
 

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -45,6 +45,10 @@ To sync your first cohort, follow these steps:
 4. Choose the sync cadence.
 5. When finished, save your work.
 
+#### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
+
+We are showing our sync as successful even if there are invalid IDs for the integration with the TradeDesk. So, the number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
+
 ### Use cases
 
 1. **Improved Audience Targeting:** By sending cohorts or segments of users from Amplitude to The Trade Desk, advertisers can refine their audience targeting. For instance, if Amplitude identifies a group of users who have exhibited certain behaviors or engagement patterns (for example, frequent app usage, specific in-app actions), you can send this cohort can to The Trade Desk for more precise ad targeting. This approach helps advertisers reach users who are more likely to convert based on their past behavior.

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -47,7 +47,7 @@ To sync your first cohort, follow these steps:
 
 ### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
-Amplitude are showing cohort sync as successful even if there are invalid IDs for the integration with the TradeDesk. The number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
+Amplitude reports a cohort sync as successful even if there are invalid IDs in the sync. As a result, the number of users in TheTradeDesk may be different than the number you have in Amplitude. If your sync contains duplicate IDs or a parsing error occurs, TheTradeDesk won't add those users.
 
 ### Use cases
 

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -47,7 +47,7 @@ To sync your first cohort, follow these steps:
 
 ### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
-Amplitude are showing our sync as successful even if there are invalid IDs for the integration with the TradeDesk. The number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
+Amplitude are showing cohort sync as successful even if there are invalid IDs for the integration with the TradeDesk. The number of added users in your cohort sync history may be different from the number you could see on the TradeDesk platform. This may occur for some reason, such as duplication or parsing errors. Thus, the number of users in the TradeDesk is the actual number they can receive from Amplitude.
 
 ### Use cases
 

--- a/docs/data/destinations/thetradedesk-cohort.md
+++ b/docs/data/destinations/thetradedesk-cohort.md
@@ -47,7 +47,7 @@ To sync your first cohort, follow these steps:
 
 ### Q: Why is the size of the cohort in Amplitude different from the number I can see in the TradeDesk?
 
-Amplitude reports a cohort sync as successful even if there are invalid IDs in the sync. As a result, the number of users in TheTradeDesk may be different than the number you have in Amplitude. If your sync contains duplicate IDs or a parsing error occurs, TheTradeDesk won't add those users.  The number of users that appears in TheTradeDesk is the number that was successfully imported from Amplitude.
+Amplitude reports a cohort sync as successful even if there are invalid IDs in the sync. As a result, the number of users in TheTradeDesk may be different than the number you have in Amplitude. If your sync contains duplicate IDs or a parsing error occurs, TheTradeDesk won't add those users. The number of users that appears in TheTradeDesk is the number that was successfully imported from Amplitude.
 
 ### Use cases
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

I added a note to answer of future inquiry from customers about the cohort size difference between Amplitude and TheTradeDesk.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
