### PR TITLE
AMP-85900 Update iOS Swift dev docs with Obj-C usage

### DIFF
--- a/docs/data/sdks/ios-swift/ampli.md
+++ b/docs/data/sdks/ios-swift/ampli.md
@@ -25,7 +25,7 @@ Amplitude Data supports tracking analytics events from iOS apps written in Swift
 1. [Install the Amplitude SDK](#install-the-amplitude-sdk)
 
     ```shell
-    pod 'AmplitudeSwift', '~> 0.6.0'
+    pod 'AmplitudeSwift', '~> 0.7.0'
     ```
 
 2. [Install the Ampli CLI](#install-the-ampli-cli)

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -11,13 +11,10 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 !!!beta "iOS Swift SDK Resources (Beta)"
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-Swift) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Swift/releases) · [:material-book: Examples](https://github.com/amplitude/Amplitude-Swift/tree/main/Examples/AmplitudeSwiftUIExample)
 
-!!!warning "Objective-C Not Supported"
-    Please note that the latest iOS SDK is NOT compatible with Objective-C projects. Use the [maintenance iOS SDK](/data/sdks/ios) if your project requires compatibility with Objective-C.
-
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
 --8<-- "includes/size/ios.md"
-    `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.6.0`.
+    `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.7.0`.
 
 ## Getting started
 
@@ -29,11 +26,20 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#ios-beta) to get started w
 
 You must initialize the SDK before you can instrument. The API key for your Amplitude project is required.
 
-```swift
-let amplitude = Amplitude(configuration: Configuration(
-    apiKey: AMPLITUDE_API_KEY
-))
-```
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(configuration: Configuration(
+        apiKey: AMPLITUDE_API_KEY
+    ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 ### `Configuration`
 
@@ -42,7 +48,7 @@ let amplitude = Amplitude(configuration: Configuration(
     | --- | --- | --- |
     | `apiKey` | The apiKey of your project. | `nil` |
     | `instanceName` | The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. | "default_instance" |
-    | `storageProvider` | Implements a custom `storageProvider` class from `Storage`. | `PersistentStorage` |
+    | `storageProvider` | Implements a custom `storageProvider` class from `Storage`. Not supported in Objective-C. | `PersistentStorage` |
     | `logLevel` | The log level enums: `LogLevelEnum.OFF`, `LogLevelEnum.ERROR`, `LogLevelEnum.WARN`, `LogLevelEnum.LOG`, `LogLevelEnum.DEBUG` | `LogLevelEnum.WARN` | 
     | `loggerProvider` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLogger` |
     | `flushIntervalMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
@@ -67,22 +73,43 @@ let amplitude = Amplitude(configuration: Configuration(
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 
-```swift
-let event = BaseEvent(
-    eventType: "Button Clicked", 
-    eventProperties: ["my event prop key": "my event prop value"]
-)
-amplitude.track(event: event)
-```
+=== "Swift"
+
+    ```swift
+    let event = BaseEvent(
+        eventType: "Button Clicked", 
+        eventProperties: ["my event prop key": "my event prop value"]
+    )
+    amplitude.track(event: event)
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPBaseEvent* event = [AMPBaseEvent initWithEventType:@"Button Clicked"
+        eventProperties:@{@"my event prop key": @"my event prop value"}];
+    
+    [amplitude track:event];
+    ```
 
 Another way to instrument basic tracking event.
 
-```swift
-amplitude.track(
-    eventType: "Button Clicked",
-    eventProperties: ["my event prop key": "my event prop value"]
-)
-```
+=== "Swift"
+
+    ```swift
+    amplitude.track(
+        eventType: "Button Clicked",
+        eventProperties: ["my event prop key": "my event prop value"]
+    )
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude track:@"Button Clicked" eventProperties:@{
+        @"my event prop key": @"my event prop value"
+    }];
+    ```
 
 ### `identify`
 
@@ -95,11 +122,21 @@ Starting from release v0.4.0, identify events with only set operations will be b
 
 You can handle the identity of a user using the identify methods. Proper use of these methods can connect events to the correct user as they move across devices, browsers, and other platforms. Send an identify call containing those user property operations to Amplitude server to tie a user's events with specific user properties.
 
-```swift
-let identify = Identify()
-identify.set(property: "color", value: "green")
-amplitude.identify(identify: identify)
-```
+=== "Swift"
+
+    ```swift
+    let identify = Identify()
+    identify.set(property: "color", value: "green")
+    amplitude.identify(identify: identify)
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPIdentify* identify = [AMPIdentify new];
+    [identify set:@"color" value:@"green"];
+    [amplitude identify:identify];
+    ```
 
 ### Tracking default events
 
@@ -108,14 +145,11 @@ Starting from release v0.6.0, the SDK can track more default events. You can con
 - Sessions [^1]
 - App lifecycles
 - Screen views[^2]
-- Deep links [^3]
 
 [^1]:
 Session tracking is the same as supported in previous versions, which was previously enabled/disabled with the [`trackingSessionEvents`](#configuration) configuration.
 [^2]:
 Screen views are supported in UIKit. For Swift UI, you need to manually call the corresponding methods.
-[^3]:
-Deep link tracking is not fully automated. You need to manually call the corresponding methods.
 
 ???config "Tracking default events options"
 | <div class="big-column">Name</div> | Type | Default Value | Description |
@@ -129,10 +163,18 @@ Use the code sample below to enable the above-mentioned tracking events.
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions.ALL
     ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking = AMPDefaultTrackingOptions.ALL;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
     ```
 
 !!!note
@@ -144,10 +186,18 @@ Use the code sample below to disable tracking the above-mentioned tracking event
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions.NONE
     ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking = AMPDefaultTrackingOptions.NONE;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
     ```
 
 Customize the tracking with `DefaultTrackingOptions`.
@@ -155,7 +205,7 @@ Customize the tracking with `DefaultTrackingOptions`.
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions(
             sessions: true,
@@ -163,6 +213,16 @@ Customize the tracking with `DefaultTrackingOptions`.
             screenViews: false
         )
     ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking.sessions = true;
+    configuration.defaultTracking.appLifecycles = false;
+    configuration.defaultTracking.screenViews = false;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
     ```
 
 #### Tracking sessions
@@ -172,14 +232,20 @@ Amplitude enables session tracking by default. Set `defaultTracking.sessions` to
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions(
-            sessions: true,
-            appLifecycles: false,
-            screenViews: false
+            sessions: true
         )
     ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking.sessions = true;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
     ```
 
 For more information about session tracking, refer to [User sessions](#user-sessions).
@@ -195,22 +261,28 @@ Set `defaultTracking.appLifecycles` to `true` to enable Amplitude to track appli
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions(
-            sessions: false,
-            appLifecycles: true,
-            screenViews: false
+            appLifecycles: true
         )
     ))
     ```
 
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking.appLifecycles = true;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
+
 When you enable this setting, Amplitude tracks the following events:
 
--`[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
--`[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
--`[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open, by observing the `UIApplicationDidFinishLaunchingNotification` or `UIApplicationWillEnterForegroundNotification` notification underneath.
--`[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application, by observing the `UIApplicationDidEnterBackgroundNotification` notification underneath.
+- `[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
+- `[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
+- `[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open, by observing the `UIApplicationDidFinishLaunchingNotification` or `UIApplicationWillEnterForegroundNotification` notification underneath.
+- `[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application, by observing the `UIApplicationDidEnterBackgroundNotification` notification underneath.
 
 #### Tracking screen views
 
@@ -223,18 +295,29 @@ Set `defaultTracking.screenViews` to `true` to enable Amplitude to track screen 
 
     ```swift
     // UIKit
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY",
         defaultTracking: DefaultTrackingOptions(
-            sessions: false,
-            appLifecycles: false,
             screenViews: true
         )
     ))
 
     // Swift UI
-    instance.configuration.defaultTracking.screenViews = false
-    instance.track(ScreenViewedEvent(screenName: "Screen Name"))
+    amplitude.configuration.defaultTracking.screenViews = false
+    amplitude.track(ScreenViewedEvent(screenName: "Screen Name"))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    // UIKit
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    configuration.defaultTracking.screenViews = true;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+
+    // Swift UI
+    amplitude.configuration.defaultTracking.screenViews = false;
+    [amplitude track:[AMPScreenViewedEvent initWithScreenName:@"Screen Name"]];
     ```
 
 When you enable this setting, Amplitude tracks the `[Amplitude] Screen Viewed` event with the screen name property. Amplitude reads this value from the controller class metadata `viewDidAppear` method swizzling.
@@ -246,13 +329,24 @@ Deeplink tracking is not automated. To track deeplinks, track the corresponding 
 === "Swift"
 
     ```swift
-    var instance = Amplitude(configuration: Configuration(
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: "API_KEY"
     ))
 
-    instance.track(DeepLinkOpenedEvent(url: URL()))
-    instance.track(DeepLinkOpenedEvent(url: "url", referrer:"refferer"))
-    instance.track(DeepLinkOpenedEvent(activity: activity))
+    amplitude.track(DeepLinkOpenedEvent(url: URL()))
+    amplitude.track(DeepLinkOpenedEvent(url: "url", referrer:"referrer"))
+    amplitude.track(DeepLinkOpenedEvent(activity: activity))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API_KEY"];
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+
+    [amplitude track:[AMPDeepLinkOpenedEvent initWithUrl:@"url"]];
+    [amplitude track:[AMPDeepLinkOpenedEvent initWithUrl:@"url" referrer:@"referrer"]];
+    [amplitude track:[AMPDeepLinkOpenedEvent initWithActivity:activity]];
     ```
 
 Amplitude tracks the `[Amplitude] Deep Link Opened` event with the URL and referrer information.
@@ -266,31 +360,60 @@ Amplitude tracks the `[Amplitude] Deep Link Opened` event with the URL and refer
 !!! example
     If Joe is in 'orgId' '15', then the `groupName` would be '15'.
 
-    ```swift
-    // set group with a single group name
-    amplitude.setGroup(groupType: "orgId", groupName: "15")
-    ```
+    === "Swift"
+
+        ```swift
+        // set group with a single group name
+        amplitude.setGroup(groupType: "orgId", groupName: "15")
+        ```
+
+    === "Objective-C"
+
+        ```obj-c
+        // set group with a single group name
+        [amplitude setGroup:@"orgId" groupName:@"15"];
+        ```
 
     If Joe is in 'orgId' 'sport', then the `groupName` would be '["tennis", "soccer"]'.
 
-    ```swift
-    // set group with multiple group names
-    amplitude.setGroup(groupType: "sport", groupName: ["tennis", "soccer"])
-    ```
+    === "Swift"
+
+        ```swift
+        // set group with multiple group names
+        amplitude.setGroup(groupType: "sport", groupName: ["tennis", "soccer"])
+        ```
+
+    === "Objective-C"
+
+        ```obj-c
+        // set group with multiple group names
+        [amplitude setGroup:@"sport" groupNames:@[@"tennis", @"soccer"]];
+        ```
 
 --8<-- "includes/event-level-groups-intro.md"
 
-```swift
-amplitude.track(
-    event: BaseEvent(
-        eventType: "event type",
-        eventProperties: [
-            "eventPropertyKey": "eventPropertyValue"
-        ], 
-        groups: ["orgId": 15]
+=== "Swift"
+
+    ```swift
+    amplitude.track(
+        event: BaseEvent(
+            eventType: "event type",
+            eventProperties: [
+                "eventPropertyKey": "eventPropertyValue"
+            ], 
+            groups: ["orgId": "15"]
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPBaseEvent* event = [AMPBaseEvent initWithEventType:@"event type"
+        eventProperties:@{@"eventPropertyKey": @"eventPropertyValue"}];
+    [event.groups set:@"orgId" value:@"15"];
+    [amplitude track:event];
+    ```
 
 ### Group identify
 
@@ -298,24 +421,48 @@ amplitude.track(
 
 --8<-- "includes/group-identify-considerations.md"
 
-```swift
-let groupType = "plan"
-let groupName = "enterprise"
-let identify = Identify().set(property: "key", value: "value")
-amplitude.groupIdentify(groupType: groupType, groupName: groupProperty, identify: groupIdentify)
-```
+=== "Swift"
+
+    ```swift
+    let groupType = "plan"
+    let groupName = "enterprise"
+    let identify = Identify().set(property: "key", value: "value")
+    amplitude.groupIdentify(groupType: groupType, groupName: groupProperty, identify: identify)
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    NSString* groupType = @"plan";
+    NSString* groupName = @"enterprise";
+    AMPIdentify* identify = [AMPIdentify new];
+    [identify set:@"key" value:@"value"];
+    [amplitude groupIdentify:groupType groupName:groupName identify:identify];
+    ```
 
 ### Track revenue
 
 Amplitude can track revenue generated by a user. Revenue is tracked through distinct revenue objects, which have special fields that are used in Amplitude's Event Segmentation and Revenue LTV charts. This allows Amplitude to automatically display data relevant to revenue in the platform. Revenue objects support the following special properties, as well as user-defined properties through the `eventProperties` field.
 
-```swift
-let revenue = Revenue()
-revenue.price = 3.99
-revenue.quantity = 3
-revenue.productId = "com.company.productId"
-amplitude.revenue(revenue: revenue)
-```
+=== "Swift"
+
+    ```swift
+    let revenue = Revenue()
+    revenue.price = 3.99
+    revenue.quantity = 3
+    revenue.productId = "com.company.productId"
+    amplitude.revenue(revenue: revenue)
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPRevenue* revenue = [AMPRevenue new];
+    revenue.price = 3.99;
+    revenue.quantity = 3;
+    revenue.productId = @"com.company.productId";
+    [amplitude revenue:revenue];
+    ```
 
 | <div class="big-column">Name</div>   | Description  |
 | --- | --- |
@@ -330,32 +477,52 @@ amplitude.revenue(revenue: revenue)
 
 If your app has its login system that you want to track users with, you can call `setUserId` at any time.
 
-```swift
-amplitude.setUserId(userId: "user@amplitude.com")
-```
+=== "Swift"
+
+    ```swift
+    amplitude.setUserId(userId: "user@amplitude.com")
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude setUserId:@"user@amplitude.com"];
+    ```
 
 ### Custom device ID
 
 You can assign a new device ID using `deviceId`. When setting a custom device ID, make sure the value is sufficiently unique. Amplitude recommends using a UUID.
 
-```swift
-amplitude.setDeviceId(NSUUID().uuidString)
-```
+=== "Swift"
+
+    ```swift
+    amplitude.setDeviceId(NSUUID().uuidString)
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude setDeviceId:[[NSUUID UUID] UUIDString]];
+    ```
 
 ### Custom storage
+
+!!!warning "Objective-C Not Supported"
 
 If you don't want to store the data in the Amplitude-defined location, you can customize your own storage by implementing the [Storage protocol](https://github.com/amplitude/Amplitude-Swift/blob/211d0c05830fab47e74fa9a053615cf422618a02/Sources/Amplitude/Types.swift#L62-L86) and setting the `storageProvider` in your configuration.
 
 Every iOS app gets a slice of storage just for itself, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory. However, if you need to expose the Documents folder in the native iOS "Files" app and don't want expose "amplitude" prefixed folder, you can customize your own storage provider to persist events on initialization.
 
-```swift
-Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        storageProvider: YourOwnStorage() // YourOwnStorage() should implement Storage
+=== "Swift"
+
+    ```swift
+    Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            storageProvider: YourOwnStorage() // YourOwnStorage() should implement Storage
+        )
     )
-)
-```
+    ```
 
 ### Reset when user logs out
 
@@ -366,9 +533,17 @@ Amplitude(
 
 With an empty `userId` and a completely new `deviceId`, the current user would appear as a brand new user in dashboard.
 
-```swift
-amplitude.reset()
-```
+=== "Swift"
+
+    ```swift
+    amplitude.reset()
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude reset];
+    ```
 
 ## Amplitude SDK plugin
 
@@ -376,7 +551,7 @@ Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying 
 
 ### Plugin.setup
 
-This method contains logic for preparing the plugin for use and has `amplitude` instance as a parameter. The expected return value is `null`. A typical use for this method, is to instantiate plugin dependencies. This method is called when the plugin is registered to the client via `amplitude.add()`.
+This method contains logic for preparing the plugin for use and has `amplitude` instance as a parameter. A typical use for this method, is to instantiate plugin dependencies. This method is called when the plugin is registered to the client via `amplitude.add()`.
 
 ### Plugin.execute
 
@@ -388,66 +563,104 @@ This method contains the logic for processing events and has `event` instance as
 
 Here's an example of a plugin that modifies each event that's instrumented by adding extra event property.
 
-```swift
-class EnrichmentPlugin: Plugin {
-    let type: PluginType
-    var amplitude: Amplitude?
+=== "Swift"
 
-    init() {
-        self.type = PluginType.enrichment
-    }
-
-    func setup(amplitude: Amplitude) {
-        self.amplitude = amplitude
-    }
-
-    func execute(event: BaseEvent?) -> BaseEvent? {
-        event?.sessionId = -1
-        if event?.eventProperties == nil {
-            event?.eventProperties = [:]
+    ```swift
+    class EnrichmentPlugin: Plugin {
+        let type: PluginType
+        var amplitude: Amplitude?
+    
+        init() {
+            self.type = PluginType.enrichment
         }
-        event?.eventProperties?["event prop key"] = "event prop value"
-        return event
+    
+        func setup(amplitude: Amplitude) {
+            self.amplitude = amplitude
+        }
+    
+        func execute(event: BaseEvent?) -> BaseEvent? {
+            event?.sessionId = -1
+            if event?.eventProperties == nil {
+                event?.eventProperties = [:]
+            }
+            event?.eventProperties?["event prop key"] = "event prop value"
+            return event
+        }
     }
-}
+    
+    amplitude.add(plugin: EnrichmentPlugin())
+    ```
 
-amplitude.add(plugin: EnrichmentPlugin())
-```
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude add:[AMPPlugin initWithType:AMPPluginTypeEnrichment
+        execute:^AMPBaseEvent* _Nullable(AMPBaseEvent* _Nonnull event) {
+        event.sessionId = -1;
+        [event.eventProperties set:@"event prop key" value:@"event prop value"];
+        return event;
+    }]];
+    ```
 
 #### Destination type plugin
 
 In destination plugin, you are able to overwrite the track(), identify(), groupIdentify(), revenue(), flush() functions.
 
-```swift
-class TestDestinationPlugin: DestinationPlugin {
-    override func track(event: BaseEvent) -> BaseEvent? {
-        return event
-    }
+!!!warning "Objective-C Not Supported"
+    Objective-C supports `flush()` and general `execute()` functions.
 
-    override func identify(event: IdentifyEvent) -> IdentifyEvent? {
-        return event
-    }
+=== "Swift"
 
-    override func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
-        return event
+    ```swift
+    class TestDestinationPlugin: DestinationPlugin {
+        override func track(event: BaseEvent) -> BaseEvent? {
+            return event
+        }
+    
+        override func identify(event: IdentifyEvent) -> IdentifyEvent? {
+            return event
+        }
+    
+        override func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
+            return event
+        }
+    
+        override func revenue(event: RevenueEvent) -> RevenueEvent? {
+            return event
+        }
+    
+        override func flush() {
+        }
+    
+        override func setup(amplitude: Amplitude) {
+            self.amplitude = amplitude
+        }
+    
+        override func execute(event: BaseEvent?) -> BaseEvent? {
+            return event
+        }
     }
+    ```
 
-    override func revenue(event: RevenueEvent) -> RevenueEvent? {
-        return event
-    }
+=== "Objective-C"
 
-    override func flush() {
-    }
-
-    override func setup(amplitude: Amplitude) {
-        self.amplitude = amplitude
-    }
-
-    override func execute(event: BaseEvent?) -> BaseEvent? {
-        return event
-    }
-}
-```
+    ```obj-c
+    [amplitude add:[AMPPlugin initWithType:AMPPluginTypeDestination
+        execute:^AMPBaseEvent* _Nullable(AMPBaseEvent* _Nonnull event) {
+        if ([event.eventType isEqualToString:@"$identify"]) {
+            // ...
+        } else if ([event.eventType isEqualToString:@"$groupidentify"]) {
+            // ...
+        } else if ([event.eventType isEqualToString:@"revenue_amount"]) {
+            // ...
+        } else {
+            // ...
+        }
+        return nil;
+    } flush:^() {
+        // ...
+    }]];
+    ```
 
 ## Troubleshooting and Debugging
 
@@ -463,45 +676,65 @@ Amplitude groups events together by session. Events that are logged within the s
 
 You can adjust the time window for which sessions are extended. The default session expiration time is 30 minutes.
 
-```swift
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        minTimeBetweenSessionsMillis: 1000
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            minTimeBetweenSessionsMillis: 1000
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.minTimeBetweenSessionsMillis = 1000;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 By default, Amplitude automatically sends the '[Amplitude] Start Session' and '[Amplitude] End Session' events. Even though these events aren't sent, sessions are still tracked by using `session_id`.
 You can also disable those session events.
 
-```swift
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        trackingSessionEvents: false
-    )
-)
-```
+=== "Swift"
 
-You can define your own session expiration time. The default session expiration time is 30 minutes.
-
-```swift
-let amplitude = Amplitude(
-    configuration: Configuration(
+    ```swift
+    let amplitude = Amplitude(configuration: Configuration(
         apiKey: AMPLITUDE_API_KEY,
-        minTimeBetweenSessionsMillis: 100000
-    )
-)
-```
+        defaultTracking: DefaultTrackingOptions(
+            sessions: false
+        )
+    ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.defaultTracking.sessions = false;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
+
+!!!note
+    `trackingSessionEvents` is deprecated and replaced with `defaultTracking.sessions`.
 
 ### Set custom user ID
 
 If your app has its login system that you want to track users with, you can call `setUserId` at any time.
 
-```swift
-amplitude.setUserId(userId: "USER_ID")
-```
+=== "Swift"
+
+    ```swift
+    amplitude.setUserId(userId: "USER_ID")
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude setUserId:@"USER_ID"];
+    ```
 
 Don't assign users a user ID that could change, because each unique user ID is a unique user in Amplitude. Learn more about how Amplitude tracks unique users in the [Help Center](https://help.amplitude.com/hc/en-us/articles/115003135607-Track-unique-users-in-Amplitude).
 
@@ -517,17 +750,38 @@ You can control the level of logs that print to the developer console.
 
 Set the log level `logLevel` with the level you want.
 
-```swift
-amplitude.logger?.logLevel = LogLevelEnum.LOG.rawValue
-```
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(configuration: Configuration(
+        apiKey: AMPLITUDE_API_KEY,
+        logLevel: LogLevelEnum.LOG
+    ))
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.logLevel = AMPLogLevelLOG;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 ### Logged out and anonymous users
 
 --8<-- "includes/logged-out-and-anonymous-users.md"
 
-```swift
-amplitude.reset();
-```
+=== "Swift"
+
+    ```swift
+    amplitude.reset()
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    [amplitude reset];
+    ```
 
 ### Disable tracking
 
@@ -535,16 +789,27 @@ By default the iOS SDK tracks several user properties such as `carrier`, `city`,
 Use the provided `TrackingOptions` interface to customize and toggle individual fields.
 Before initializing the SDK with your apiKey, create a `TrackingOptions` instance with your configuration and set it on the SDK instance.
 
-```swift
-let trackingOptions = TrackingOptions()
-trackingOptions.disableCity().disableIpAddress().disableLatLng()
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        trackingOptions: trackingOptions
+=== "Swift"
+
+    ```swift
+    let trackingOptions = TrackingOptions()
+    trackingOptions.disableTrackCity().disableTrackIpAddress()
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            trackingOptions: trackingOptions
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    [configuration.trackingOptions disableTrackCity];
+    [configuration.trackingOptions disableTrackIpAddress];
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 Tracking for each field can be individually controlled, and has a corresponding method (for example, `disableCountry`, `disableLanguage`).
 
@@ -578,14 +843,24 @@ Amplitude determines the user's mobile carrier using [`CTTelephonyNetworkInfo`](
 
 COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, city, IP address and location tracking can all be enabled or disabled at one time. Apps that ask for information from children under 13 years of age must comply with COPPA.
 
-```swift
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        enableCoppaControl: true
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            enableCoppaControl: true
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.enableCoppaControl = true;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 ### Advertiser ID
 
@@ -605,10 +880,17 @@ To retrieve the IDFA and add it to the tracking events, you can follow this [exa
 
 --8<-- "includes/sdk-device-id/get-device-id.md"
 
-```swift
-let deviceId = amplitude.getDeviceId()
-```
+=== "Swift"
 
+    ```swift
+    let deviceId = amplitude.getDeviceId()
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    NSString* deviceId = [amplitude getDeviceId];
+    ```
 To set the device, refer to [custom device ID](./#custom-device-id).
 
 ### Location tracking
@@ -619,53 +901,88 @@ Amplitude converts the IP of a user event into a location (GeoIP lookup) by defa
 
 Users may wish to opt out of tracking entirely, which means Amplitude doesn't track any of their events or browsing history. `OptOut` provides a way to fulfill a user's requests for privacy.
 
-```swift
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        optOut: true
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            optOut: true
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.optOut = true;
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 ### Set log callback
 
 Implements a customized `loggerProvider` class from the LoggerProvider, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.
 
-```swift
-class SampleLogger: Logger {
-    typealias LogLevel = LogLevelEnum
+=== "Swift"
 
-    var logLevel: Int
-
-    init(logLevel: Int = LogLevelEnum.OFF.rawValue) {
-        self.logLevel = logLevel
+    ```swift
+    class SampleLogger: Logger {
+        typealias LogLevel = LogLevelEnum
+    
+        var logLevel: Int
+    
+        init(logLevel: Int = LogLevelEnum.OFF.rawValue) {
+            self.logLevel = logLevel
+        }
+    
+        func error(message: String) {
+            // TODO: handle error message
+        }
+    
+        func warn(message: String) {
+            // TODO: handle warn message
+        }
+    
+        func log(message: String) {
+            // TODO: handle log message
+        }
+    
+        func debug(message: String) {
+            // TODO: handle debug message
+        }
     }
-
-    func error(message: String) {
-        // TODO: handle error message
-    }
-
-    func warn(message: String) {
-        // TODO: handle warn message
-    }
-
-    func log(message: String) {
-        // TODO: handle log message
-    }
-
-    func debug(message: String) {
-        // TODO: handle debug message
-    }
-}
-
-let amplitude = Amplitude(
-    configuration: Configuration(
-        apiKey: AMPLITUDE_API_KEY,
-        loggerProvider: SampleLogger()
+    
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: AMPLITUDE_API_KEY,
+            loggerProvider: SampleLogger()
+        )
     )
-)
-```
+    ```
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:AMPLITUDE_API_KEY];
+    configuration.loggerProvider = ^(NSInteger logLevel, NSString* _Nonnull message) {
+        switch(logLevel) {
+        case AMPLogLevelERROR:
+            // TODO: handle error message
+            break;
+        case AMPLogLevelWARN:
+            // TODO: handle warn message
+            break;
+        case AMPLogLevelLOG:
+            // TODO: handle log message
+            break;
+        case AMPLogLevelDEBUG:
+            // TODO: handle debug message
+            break;
+        }
+    };
+    Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+    ```
 
 ### More resources
 

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -708,55 +708,104 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
 
     --8<-- "includes/sdk-quickstart/quickstart-initialization.md"
 
-    ```swift
-    import AmplitudeSwift
+    === "Swift"
 
-    let amplitude = Amplitude(
-        configuration: Configuration(
-            apiKey: "YOUR-API-KEY"
+        ```swift
+        import AmplitudeSwift
+    
+        let amplitude = Amplitude(
+            configuration: Configuration(
+                apiKey: "YOUR-API-KEY"
+            )
         )
-    )
-    ```
+        ```
+
+    === "Objective-C"
+    
+        ```obj-c
+        @import AmplitudeSwift;
+
+        AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"YOUR-API-KEY"];
+        Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+        ```
+
     --8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
 
-    ```swift
-    import AmplitudeSwift
+    === "Swift"
 
-    let amplitude = Amplitude(
-        Configuration(
-            apiKey: "YOUR-API-KEY",
-            serverZone: ServerZone.EU
+        ```swift
+        import AmplitudeSwift
+    
+        let amplitude = Amplitude(
+            Configuration(
+                apiKey: "YOUR-API-KEY",
+                serverZone: ServerZone.EU
+            )
         )
-    )
-    ```
+        ```
+
+    === "Objective-C"
+    
+        ```obj-c
+        @import AmplitudeSwift;
+
+        AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"YOUR-API-KEY"];
+        configuration.serverZone = AMPServerZoneEU;
+        Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+        ```
 
     --8<-- "includes/sdk-quickstart/quickstart-send-data.md"
 
-    ```swift
-    amplitude.track(
-        eventType: "Button Clicked",
-        eventProperties: ["my event prop key": "my event prop value"]
-    )
-    ```
+    === "Swift"
+
+        ```swift
+        amplitude.track(
+            eventType: "Button Clicked",
+            eventProperties: ["my event prop key": "my event prop value"]
+        )
+        ```
+
+    === "Objective-C"
+    
+        ```obj-c
+        [amplitude track:@"Button Clicked" eventProperties:@{
+            @"my event prop key": @"my event prop value"
+        }];
+        ```
 
     --8<-- "includes/sdk-quickstart/quickstart-check-for-success.md"
 
     --8<-- "includes/sdk-quickstart/quickstart-complete-code-example.md"
 
-    ```swift
-    import AmplitudeSwift
+    === "Swift"
 
-    let amplitude = Amplitude(
-        configuration: Configuration(
-            apiKey: "YOUR-API-KEY"
+        ```swift
+        import AmplitudeSwift
+    
+        let amplitude = Amplitude(
+            configuration: Configuration(
+                apiKey: "YOUR-API-KEY"
+            )
         )
-    )
+    
+        amplitude.track(
+            eventType: "Button Clicked",
+            eventProperties: ["my event prop key": "my event prop value"]
+        )
+        ```
 
-    amplitude.track(
-        eventType: "Button Clicked",
-        eventProperties: ["my event prop key": "my event prop value"]
-    )
-    ```
+    === "Objective-C"
+    
+        ```obj-c
+        @import AmplitudeSwift;
+
+        AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"YOUR-API-KEY"];
+        Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
+
+        [amplitude track:@"Button Clicked" eventProperties:@{
+            @"my event prop key": @"my event prop value"
+        }];
+        ```
 
     Learn more available functionalities in [iOS SDK](./ios-swift/index.md).
 

--- a/includes/sdk-ios/swift-install-dependencies.md
+++ b/includes/sdk-ios/swift-install-dependencies.md
@@ -6,7 +6,7 @@ Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Packag
 
     1. Add dependency to `Podfile`. 
     ```bash
-    pod 'AmplitudeSwift', '~> 0.6.0'
+    pod 'AmplitudeSwift', '~> 0.7.0'
     ```
     2. Run `pod install` in the project directory to install the dependency. 
 
@@ -22,6 +22,6 @@ Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Packag
 
     Add the following line to your `Cartfile`.
     ```bash
-    github "amplitude/Amplitude-Swift" ~> 0.6.0
+    github "amplitude/Amplitude-Swift" ~> 0.7.0
     ```
     Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.

--- a/macros/sdks/ios-install-dependencies.md
+++ b/macros/sdks/ios-install-dependencies.md
@@ -1,4 +1,4 @@
-@{% macro ios_install_dependencies(packageName='AmplitudeSwift', version='0.6.0', repo='amplitude/Amplitude-Swift') -%}
+@{% macro ios_install_dependencies(packageName='AmplitudeSwift', version='0.7.0', repo='amplitude/Amplitude-Swift') -%}
 Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Package Manager. 
 
 === "CocoaPods"


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Updates iOS Swift dev docs with Obj-C usage.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
