### PR TITLE
Remove Accessibe

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ theme:
 extra_css:
   - stylesheets/extra.css # Amplitude Styles
 extra_javascript:
-  - /javascripts/accessibe.js # Script for Accessibe. Don't remove without speaking to Legal
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js # Tablesort
   - /javascripts/tablesort.js #script for Tablesort feature
   - /javascripts/anchor-copy.js #script for copying anchor links


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Removing the Accessibe widget. We aren't using it as a company any longer, and both Legal and design gave it the go ahead to remove.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
