### PR TITLE
[DDI-438] Fix Experiment RN legacy naming and badge

### DIFF
--- a/docs/experiment/sdks/react-native-sdk-legacy.md
+++ b/docs/experiment/sdks/react-native-sdk-legacy.md
@@ -1,5 +1,5 @@
 ---
-title: Experiment React Native SDK
+title: Experiment React Native SDK (legacy)
 description: Official documentation for Amplitude Experiment's Client-side React Native SDK.
 icon: simple/react
 ---
@@ -19,7 +19,7 @@ Official documentation for Amplitude Experiment's Client-side React Native SDK.
 !!!warning "Web Compatibility"
     Experiment React Native SDK is only compatible with iOS and Android React Native projects. Use the [JavaScript SDK](./javascript-sdk.md) to support all three platforms.
 
-[![npm version](https://badge.fury.io/js/@amplitude%2Fexperiment-react-native-client.svg)](https://badge.fury.io/js/@amplitude%2Fexperiment-react-native-client)
+<a href="https://badge.fury.io/js/@amplitude%2Fexperiment-react-native-client"><img src="https://badge.fury.io/js/@amplitude%2Fexperiment-react-native-client.svg" alt="npm version" height="18"></a>
 
 Install the Experiment JavaScript Client SDK.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -424,7 +424,7 @@ nav:
         - Python SDK: experiment/sdks/python-sdk.md
         - Evaluation Proxy: experiment/infra/evaluation-proxy.md
         - Maintenance:
-          - React Native SDK: experiment/sdks/react-native-sdk-legacy.md
+          - React Native SDK (legacy): experiment/sdks/react-native-sdk-legacy.md
       - REST APIs:
         - Evaluation API: experiment/apis/evaluation-api.md
         - Management API:


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Renames the old Experiment React Native SDK to include `(legacy)` in the title.

Also fixed NPM badge image link.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
