### PR TITLE
SKY-3483 update props syntax

### DIFF
--- a/docs/experiment/apis/management-api/api-beta.md
+++ b/docs/experiment/apis/management-api/api-beta.md
@@ -637,7 +637,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/api-beta.md
+++ b/docs/experiment/apis/management-api/api-beta.md
@@ -637,7 +637,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/api-beta.md
+++ b/docs/experiment/apis/management-api/api-beta.md
@@ -637,7 +637,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. |
+|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/experiments.md
+++ b/docs/experiment/apis/management-api/experiments.md
@@ -1082,7 +1082,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/experiments.md
+++ b/docs/experiment/apis/management-api/experiments.md
@@ -1082,7 +1082,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/experiments.md
+++ b/docs/experiment/apis/management-api/experiments.md
@@ -1082,7 +1082,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. |
+|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/flags.md
+++ b/docs/experiment/apis/management-api/flags.md
@@ -991,7 +991,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. |
+|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/flags.md
+++ b/docs/experiment/apis/management-api/flags.md
@@ -991,7 +991,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 

--- a/docs/experiment/apis/management-api/flags.md
+++ b/docs/experiment/apis/management-api/flags.md
@@ -991,7 +991,7 @@ The `conditions` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition. Custom and free-form properties must be prefixed with `gp:` |
+|`prop`| Required | string | The property to use in the condition. Prefix custom and free-form properties with  `gp:` |
 |`op`| Required | string | The [operation](#op) to use in this condition. |
 |`values`| Required | string array | The values to use in the operation. |
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update documentation for MGT API. [SKY-3483](https://amplitude.atlassian.net/browse/SKY-3483)

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[SKY-3483]: https://amplitude.atlassian.net/browse/SKY-3483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ