### PR TITLE
AMP-87647 Remove deprecated fields from BigQuery export schema

### DIFF
--- a/docs/data/destinations/bigquery.md
+++ b/docs/data/destinations/bigquery.md
@@ -72,10 +72,11 @@ The **Event** table schema includes the following columns:
 <!-- vale off-->
 | <div class="big-column">Column</div>| Type | Description |
 |---|---|---|
-| `Adid` | String | (Android) Google Play Services advertising ID (ADID). Example: AEBE52E7-03EE-455A-B3C4-E57283966239 |
-| `amplitude_event_type` | VARCHAR(1677721) | Amplitude specific identifiers based on events Amplitude generates. This is a legacy field so event_type should suffice for all queries  |
+| `Adid` | STRING | (Android) Google Play Services advertising ID (ADID). Example: AEBE52E7-03EE-455A-B3C4-E57283966239 |
+| `amplitude_attribution_ids` | STRING | Hashed attribution ids on the event  |
+| `amplitude_event_type` | STRING | Amplitude specific identifiers based on events Amplitude generates. This is a legacy field so event_type should suffice for all queries  |
 | `amplitude_id` | BIGNUMERIC | The original Amplitude ID for the user. Use this field to automatically handle merged users. Example: 2234540891 |
-| `app` | INT64 | Project ID found in your project's Settings page. Example: 123456 |
+| `app` | INTEGER | Project ID found in your project's Settings page. Example: 123456 |
 | `city` | STRING | City. Example: “San Francisco” |
 | `client_event_time` | TIMESTAMP | Local timestamp (UTC) of when the device logged the event. Example: `2015-08-10T12:00:00.000000` |
 | `client_upload_time` | TIMESTAMP | The local timestamp (UTC) of when the device uploaded the event. Example: `2015-08-10T12:00:00.000000` |
@@ -89,19 +90,19 @@ The **Event** table schema includes the following columns:
 | `device_model` | STRING | Device model. Example: iPad Mini |
 | `device_type` | STRING | Device type. Example: Apple iPhone 5s |
 | `dma` | STRING | Designated marketing area (DMA). Example; San Francisco-Oakland-San Jose, CA |
-| `event_id` | INT64 | A counter that distinguishes events. Example: 1 |
+| `event_id` | INTEGER | A counter that distinguishes events. Example: 1 |
 | `event_properties` | JSON |    |
 | `event_time` | TIMESTAMP | Amplitude timestamp (UTC) which is the `client_event_time` adjusted by the difference between `server_received_time` and `client_upload_time`, specifically: `event_time` = `client_event_time` + (`server_received_time` - `client_upload_time`)   Amplitude uses this timestamp is used to organize events on Amplitude charts. NOTE: If the difference between server_received_time and client_upload_time is less than 60 seconds, the `event_time` isn't adjusted and equals the `client_event_time`. Example: `2015-08-10T12:00:00.000000` |
-| `followed_an_identify` | BOOL | True if there was an identify event between this current SDK event and the last SDK event seen. Example: `True` |
+| `followed_an_identify` | BOOLEAN | True if there was an identify event between this current SDK event and the last SDK event seen. Example: `True` |
 | `group_properties` | JSON |    |
 | `groups` | JSON | Group types. See the Accounts documentation for more information.   |
 | `idfa` | STRING | (iOS) Identifier for Advertiser. Example: AEBE52E7-03EE-455A-B3C4-E57283966239 |
 | `ip_address` | STRING | IP address. Example: "123.11.111.11" |
-| `is_attribution_event` | BOOL |     |
+| `is_attribution_event` | BOOLEAN |     |
 | `language` | STRING |     |
 | `library` | STRING |     |
-| `location_lat` | FLOAT64 | Latitude. Example: 12.3456789 |
-| `location_lng` | FLOAT64 | Longitude. Example: -123.4567890 |
+| `location_lat` | FLOAT | Latitude. Example: 12.3456789 |
+| `location_lng` | FLOAT | Longitude. Example: -123.4567890 |
 | `os_name` | STRING | OS name. Example: `ios` |
 | `os_version` | STRING | OS version. | 1.0 |
 | `paying` | STRING | True if the user has ever logged any revenue, otherwise (none).   Note: The property value can be modified via the Identify API. Example: true |

--- a/docs/data/destinations/bigquery.md
+++ b/docs/data/destinations/bigquery.md
@@ -73,8 +73,6 @@ The **Event** table schema includes the following columns:
 | <div class="big-column">Column</div>| Type | Description |
 |---|---|---|
 | `Adid` | STRING | (Android) Google Play Services advertising ID (ADID). Example: AEBE52E7-03EE-455A-B3C4-E57283966239 |
-| `amplitude_attribution_ids` | STRING | Hashed attribution ids on the event  |
-| `amplitude_event_type` | STRING | Amplitude specific identifiers based on events Amplitude generates. This is a legacy field so event_type should suffice for all queries  |
 | `amplitude_id` | BIGNUMERIC | The original Amplitude ID for the user. Use this field to automatically handle merged users. Example: 2234540891 |
 | `app` | INTEGER | Project ID found in your project's Settings page. Example: 123456 |
 | `city` | STRING | City. Example: “San Francisco” |
@@ -82,12 +80,9 @@ The **Event** table schema includes the following columns:
 | `client_upload_time` | TIMESTAMP | The local timestamp (UTC) of when the device uploaded the event. Example: `2015-08-10T12:00:00.000000` |
 | `country` | STRING | Country. Example: "United States" |
 | `data` | JSON | Dictionary where certain fields such as `first_event` and `merged_amplitude_id` are stored |   |
-| `device_brand` | STRING | Device brand. Example: Apple |
 | `device_carrier` | STRING | Device Carrier. Example: Verizon |
 | `device_family` | STRING | Device family. Example: Apple iPhone |
 | `device_id` | STRING | The device specific identifier. Example: C8F9E604-F01A-4BD9-95C6-8E5357DF265D |
-| `device_manufacturer` | STRING | Device manufacturer. Example: Apple |
-| `device_model` | STRING | Device model. Example: iPad Mini |
 | `device_type` | STRING | Device type. Example: Apple iPhone 5s |
 | `dma` | STRING | Designated marketing area (DMA). Example; San Francisco-Oakland-San Jose, CA |
 | `event_id` | INTEGER | A counter that distinguishes events. Example: 1 |
@@ -114,7 +109,6 @@ The **Event** table schema includes the following columns:
 | `server_upload_time` | TIMESTAMP | Amplitude timestamp (UTC) of when Amplitude servers received the event. Example:  `2015-08-10T12:00:00.000000` |
 | `session_id` | BIGNUMERIC | The session start time in milliseconds since epoch. Example: 1396381378123 |
 | `start_version` | STRING | App version the user was first tracked on. Example: 1.0.0 |
-| `user_creation_time` | TIMESTAMP | Event_time (UTC) of the user's first event. Example: `2015-08-10T12:00:00.000000` |
 | `user_id` | STRING | A readable ID specified by you. Should be something that doesn't change; for that reason, using the user's email address isn't recommended.  |
 | `user_properties` | JSON |    |
 | `uuid` | STRING | A unique identifier per row (event sent). Example: bf0b9b2a-304d-11e6-934f-22000b56058f |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Remove deprecated fields from BigQuery export schema and other minor fix. See https://community.amplitude.com/announcements-56/deprecating-fields-from-the-export-data-format-1850 for the deprecation announcement.



## Deadline

ASAP, but no real deadline


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
