### PR TITLE
AMP-88654 remove outdated READ_PHONE_STATE permission warning

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -45,7 +45,7 @@ This is the official documentation for the Amplitude Analytics Android SDK.
 2. Sync project with Gradle files.
 3. To report events to Amplitude, add the INTERNET permission to your `AndroidManifest.xml` file:
     `<uses-permission android:name="android.permission.INTERNET" />`
-4. For Android 6.0 (Marshmallow) and higher, explicitly add the `READ_PHONE_STATE` permission to fetch phone related information. `<uses-permission android:name="android.permission.READ_PHONE_STATE" />`
+4. For Android 6.0 (Marshmallow) and higher, explicitly add permission to fetch the device [advertising ID](/data/sdks/android/#advertiser-id).
 <!--vale on-->
 After you've installed the SDK and its dependencies, import Amplitude into any file that uses it.
 

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -333,10 +333,7 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
     <uses-permission android:name="android.permission.INTERNET" />
     ```
 
-    For Android 6.0 (Marshmallow) and above, explicitly add the `READ_PHONE_STATE` permission to fetch phone carrier information. If you don't add this permission, the SDK still works, but doesn't track phone carrier information.
-    ```
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    ```
+    For Android 6.0 (Marshmallow) and higher, explicitly add permission to fetch the device [advertising ID](/data/sdks/android/#advertiser-id). 
 
     The SDK internally uses a few Java 8 language APIs through desugaring. Make sure your project either [enables desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) or requires a minimum API level of 16.
 


### PR DESCRIPTION
https://amplitude.atlassian.net/browse/AMP-88654

## Description

I was able to retrieve carrier information without the READ_PHONE_STATE permission.

I looked at [the DeviceInfo we retrieve](https://github.com/amplitude/Amplitude-Android/blob/4e37e0f2d21c437af2b4f4bb58520b061a21a2be/src/main/java/com/amplitude/api/DeviceInfo.java#L114-L122) and it seems most can be done without the extra permission.
For carrier we use [TelephonyManager.getNetworkOperatorName()](https://developer.android.com/reference/android/telephony/TelephonyManager#getNetworkOperatorName()) which has no required permissions.

As far as I can tell the only thing that requires extra permissions is getting the Advertising ID.

![image](https://github.com/amplitude/amplitude-dev-center/assets/5790872/821da41f-124c-46b2-9317-42a02766d34b)


## Change type

- [x] Doc bug fix. Fixes #[AMP-88654](https://amplitude.atlassian.net/browse/AMP-88654). 





@amplitude-dev-docs


[AMP-88654]: https://amplitude.atlassian.net/browse/AMP-88654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ