### PR TITLE
AMP-87063 Profile API update throttling limit

### DIFF
--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -40,8 +40,7 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
 **Throttling errors**
 
-- Amplitude orgs have a limit of 600 all API requests per minute. If you go above this limit, the API returns the following error response:
-    - `{"error":"Number of requests exceeded allocated quota in the last minute. Please contact Amplitude team with your use case if you need to increase the quota"}`
+- Amplitude orgs have a limit of 600 all API requests per minute. If you go above this limit, contact Support with the use case and required limit.
 - Amplitude orgs have a limit of 100,000 recommendation requests per minute. If you go above this limit, the API returns the following error response:
     - `{"error":"Number of requests per minute exceeds system limit. Contact Support if you need this limit raised"}`
 - For batch recommendation use cases, consider rate limiting your requests so you don't go above this limit.

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -40,6 +40,8 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
 **Throttling errors**
 
+- Amplitude orgs have a limit of 600 all API requests per minute. If you go above this limit, the API returns the following error response:
+    - `{"error":"Number of requests exceeded allocated quota in the last minute. Please contact Amplitude team with your use case if you need to increase the quota"}`
 - Amplitude orgs have a limit of 100,000 recommendation requests per minute. If you go above this limit, the API returns the following error response:
     - `{"error":"Number of requests per minute exceeds system limit. Contact Support if you need this limit raised"}`
 - For batch recommendation use cases, consider rate limiting your requests so you don't go above this limit.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Profile API will have throttling soon -- default to 600 TPM (Time per minute) and customize for existing heavy users. 

Feature is tracked on JIRA: https://amplitude.atlassian.net/browse/AMP-87063  and will roll out later. 

Thus prepare a doc update so later I can merge this when we enable the feature. 

Add 2nd owner + PM to be aware of changes. 

## Deadline

N/A. Late Nov or Dec,  this feature is in dryrun mode to ensure smooth customer experience. JIRA: https://amplitude.atlassian.net/browse/AMP-87063 

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
