### PR TITLE
DDI 442 Session Replay

### DIFF
--- a/.github/styles/Amplitude/Headings.yml
+++ b/.github/styles/Amplitude/Headings.yml
@@ -99,3 +99,4 @@ exceptions:
   - Data APIs
   - Official Postman Collection
   - Google Analytics
+  - Session Replay

--- a/.github/styles/Amplitude/Headings.yml
+++ b/.github/styles/Amplitude/Headings.yml
@@ -100,3 +100,4 @@ exceptions:
   - Official Postman Collection
   - Google Analytics
   - Session Replay
+  - (Actions)

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -1,5 +1,27 @@
 ---
-title: Session Replay
+title: Amplitude Session Replay Overview
 ---
 
-Here is some sample content
+This page provides links to documentation that explains how to instrument Session Replay in your web application.
+
+## SDKs
+
+Amplitude provides a plugin SDK for use with Amplitude's Browser SDK and a standalone SDK for use with third-party analytics providers.
+
+<div class="grid cards" markdown>
+
+- :material-power-plug:{ .lg .middle } __Plugin SDK__
+
+    ---
+
+    Use this SDK if you instrumented your web app with [Amplitude's Browser SDK 2](/data/sdks/browser-2/).
+
+    [:octicons-arrow-right-24: Plugin SDK](/session-replay/sdks/plugin/)
+
+- :fontawesome-solid-gear:{ .lg .middle } __Standalone SDK__
+
+    ---
+
+    Use this SDK if you instrumented your web app third-party analytics, like Segment.
+
+    [:octicons-arrow-right-24: Plugin SDK](/session-replay/sdks/standalone/)

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -24,4 +24,4 @@ Amplitude provides a plugin SDK for use with Amplitude's Browser SDK and a stand
 
     Use this SDK if you instrumented your web app third-party analytics, like Segment.
 
-    [:octicons-arrow-right-24: Plugin SDK](/session-replay/sdks/standalone/)
+    [:octicons-arrow-right-24: Standalone SDK](/session-replay/sdks/standalone/)

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -14,7 +14,7 @@ Amplitude provides a plugin for use with Amplitude's Browser SDK and a standalon
 
     ---
 
-    Use this Plugin if you instrumented your web app with [Amplitude's Browser SDK 2](/data/sdks/browser-2/).
+    Use this Plugin if you instrumented your web app with [Amplitude's Browser SDK 2.0](/data/sdks/browser-2/).
 
     [:octicons-arrow-right-24: Plugin](/session-replay/sdks/plugin/)
 

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -1,0 +1,5 @@
+---
+title: Session Replay
+---
+
+Here is some sample content

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -6,15 +6,15 @@ This page provides links to documentation that explains how to instrument Sessio
 
 ## SDKs
 
-Amplitude provides a plugin SDK for use with Amplitude's Browser SDK and a standalone SDK for use with third-party analytics providers.
+Amplitude provides a plugin for use with Amplitude's Browser SDK and a standalone SDK for use with third-party analytics providers.
 
 <div class="grid cards" markdown>
 
-- :material-power-plug:{ .lg .middle } __Plugin SDK__
+- :material-power-plug:{ .lg .middle } __Plugin__
 
     ---
 
-    Use this SDK if you instrumented your web app with [Amplitude's Browser SDK 2](/data/sdks/browser-2/).
+    Use this Plugin if you instrumented your web app with [Amplitude's Browser SDK 2](/data/sdks/browser-2/).
 
     [:octicons-arrow-right-24: Plugin SDK](/session-replay/sdks/plugin/)
 

--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -16,7 +16,7 @@ Amplitude provides a plugin for use with Amplitude's Browser SDK and a standalon
 
     Use this Plugin if you instrumented your web app with [Amplitude's Browser SDK 2](/data/sdks/browser-2/).
 
-    [:octicons-arrow-right-24: Plugin SDK](/session-replay/sdks/plugin/)
+    [:octicons-arrow-right-24: Plugin](/session-replay/sdks/plugin/)
 
 - :fontawesome-solid-gear:{ .lg .middle } __Standalone SDK__
 

--- a/docs/session-replay/sdks/index.md
+++ b/docs/session-replay/sdks/index.md
@@ -1,0 +1,3 @@
+---
+title: Session Replay SDKs
+---

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -218,12 +218,19 @@ Session Replay doesn't set cookies on the user's browser. Instead, it relies on 
 
 Keep the following limitations in mind as you implement Session Replay:
 
+- Session Replay doesn't stitch together replays from a single user across multiple projects. For example:
+  
+    - You instrument your marketing site and web application as separate Amplitude projects with Session Replay enabled in each.
+    - A known user begins on the marketing site, and logs in to the web application.
+    - Amplitude captures both sessions.
+    - The replay for each session is available for view in the host project.
+
 - The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
 - Session Replay can't capture the following HTML elements:
 
     - Canvas
     - WebGL
-    - `<object>` tags, other than `<object type="image">`
+    - `<object>` tags including plugins like Flash, Silverlight, or Java. Session replay supports `<object type="image">`
     - Lottie animations
     - `<iframe>` elements from a different origin
     - Assets that require authentication, like fonts, CSS, or images

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -1,0 +1,3 @@
+---
+title: Session Replay Browser SDK Plugin
+---

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -4,14 +4,7 @@ title: Session Replay Browser SDK Plugin
 
 This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/session-replay/sdks/standalone).
 
-!!! info "Session Replay and performance"
-    Amplitude built Session Replay to minimize impact on the performance of web pages on which it's installed by:
-
-    - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
-    - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
-    - Optimizing DOM processing.
-
-Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
+--8<-- "includes/session-replay/performance.md"
 
 ## Before you begin
 
@@ -22,9 +15,7 @@ The Session Replay Plugin requires that:
 1. Your application is web-based.
 2. You can provide a device ID to the SDK.
 
-### Supported browsers
-
-Session replay supports the same set of browsers as Amplitude's SDKs. For more information, see [Browser Compatibility](https://help.amplitude.com/hc/en-us/articles/360024709711).
+--8<-- "includes/session-replay/browsers.md"
 
 ## Quickstart
 
@@ -102,56 +93,13 @@ Session replay requires that you configure default session event tracking. This 
     });
     ```
 
-### Mask on-screen data
+--8<-- "includes/session-replay/mask-onscreen-data.md"
 
-The Session Replay SDK offers three ways to mask user input, text, and other HTML elements.
+--8<-- "includes/session-replay/user-opt-out.md"
 
-| Element           | Description                                                                                                                                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay captures asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
-| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay captures masked text as a series of asterisks.                                                                 |
-| non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |
+--8<-- "includes/session-replay/eu-data-residency.md"
 
-### User opt-out
-
-Session Replay provides an option for opt-out configuration. This prevents Amplitude from collecting session replays when passed as part of initialization. For example:
-
-```js
-// Pass a boolean value to indicate a users opt-out status
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  optOut: true,
-}).promise;
-```
-
-### EU data residency
-
-Session Replay is available to Amplitude Customers who use the EU data center. Set the `serverZone` configuration option to `EU` during initialization. For example:
-
-```js
-// For European users, set the serverZone to "EU" 
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  serverZone: "EU",
-}).promise;
-```
-
-### Sampling rate
-
- By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
-
-```js
-// This configuration samples 40% of all sessions
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  sampleRate: 0.4
-}).promise;
-```
-
-To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly sessions, your quota is 83% of your average sessions. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
-
-Keep the following in mind as you consider your sample rate:
-
-- When you reach your monthly session quote, Amplitude stops capturing sessions for replay.
-- Session quotas reset on the first of every month.
-- Use sample rate to distribute your session quota over the course of a month, rather than using your full quote at the beginning of the month.
+--8<-- "includes/session-replay/sampling-rate.md"
 
 ### Disable replay collection
 
@@ -181,70 +129,11 @@ if (nonEUCountryFlagEnabled) {
 }
 ```
 
-## Data retention, deletion, and privacy
+--8<-- "includes/session-replay/data-retention.md"
 
-Session replay uses existing Amplitude tools and APIs to handle privacy and deletion requests.
+--8<-- "includes/session-replay/replay-storage.md"
 
-### Retention period
-
-By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
-
-Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
-
-### DSAR API
-
-The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
-
-```json
-{
-  "amplitude_id": 123456789,
-  "app": 12345,
-  "event_time": "2020-02-15 01:00:00.123456",
-  "event_type": "first_event",
-  "server_upload_time": "2020-02-18 01:00:00.234567",
-  "device_id": "your device id",
-  "user_properties": { ... }
-  "event_properties": {
-    "[Amplitude] Session Replay ID": "cb6ade06-cbdf-4e0c-8156-32c2863379d6/1699922971244"
-  }
-  "session_id": 1699922971244,
-}
-```
-
-### Data deletion
-
-Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-api/) to handle deletion requests. Successful deletion requests remove all session replays for the specified user.
-
-When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
-
-### Bot filter
-
-Session Replay uses the same [block filter](https://help.amplitude.com/hc/en-us/articles/14884769332507-Block-bot-web-traffic) available in the Amplitude app. Session Replay doesn't block traffic based on event or user properties.
-
-## Session Replay storage
-
-Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The plugin cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
-
-## Known limitations
-
-Keep the following limitations in mind as you implement Session Replay:
-
-- Session Replay doesn't stitch together replays from a single user across multiple projects. For example:
-  
-    - You instrument your marketing site and web application as separate Amplitude projects with Session Replay enabled in each.
-    - A known user begins on the marketing site, and logs in to the web application.
-    - Amplitude captures both sessions.
-    - The replay for each session is available for view in the host project.
-
-- The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
-- Session Replay can't capture the following HTML elements:
-
-    - Canvas
-    - WebGL
-    - `<object>` tags including plugins like Flash, Silverlight, or Java. Session replay supports `<object type="image">`
-    - Lottie animations
-    - `<iframe>` elements from a different origin
-    - Assets that require authentication, like fonts, CSS, or images
+--8<-- "includes/session-replay/known-limitations.md"
 
 ### Multiple Amplitude instances
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -1,3 +1,210 @@
 ---
 title: Session Replay Browser SDK Plugin
 ---
+
+This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/docs/session-replay/sdks/standalone).
+
+## Before you begin
+
+For best results, use the latest version of the Session Replay standalone SDK. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
+
+Session Replay requires that:
+
+1. Your application is JavaScript-based.
+2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
+3. You can provide a device ID to the SDK.
+
+## Quickstart
+
+Install the standalone SDK with yarn or npm.
+
+=== "npm"
+
+    ```bash
+    npm install @amplitude/plugin-session-replay-browser --save
+    ```
+
+=== "yarn"
+
+    ```bash
+    yarn add @amplitude/plugin-session-replay-browser
+    ```
+
+Configure your application code.
+
+```js
+import * as amplitude from '@amplitude/analytics-browser';
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+
+// Your existing initialization logic with Browser SDK
+amplitude.init(API_KEY);
+
+// Create and Install Session Replay Plugin
+const sessionReplayTracking = sessionReplayPlugin();
+amplitude.add(sessionReplayTracking);
+```
+
+You can also add the code directly to the `<head>` of your site.
+
+```html
+<script src="https://cdn.amplitude.com/libs/analytics-browser-2.1.3-min.js.gz"></script>
+<script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-0.6.13-min.js.gz"></script>
+<script>
+window.amplitude.init(API_KEY)
+const sessionReplayTracking = window.sessionReplay.plugin();
+window.amplitude.add(sessionReplayTracking);
+</script>
+```
+
+## Configuration
+
+Pass the following option when you initialize the Session Replay plugin:
+
+| Name              | Type      | Required | Default         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ----------------- | --------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sampleRate`      | `number`  | No       | `0`             | Use this option to control how many sessions to select for replay collection. <br></br>The number should be a decimal between 0 and 1, for example `0.4`, representing the fraction of sessions to have randomly selected for replay collection. Over a large number of sessions, `0.4` would select `40%` of those sessions. |
+
+### Track default session events
+
+Session replay requires that you configure default session event tracking. This ensures that Session Replay captures Session Start and Session End events. If you didn't capture these events before you implement Session Replay, expect an increase in event volume. For more information about session tracking, see [Browser SDK 2.0 | Tracking Sessions](/data/sdks/browser-2/#tracking-sessions).
+
+=== "SDK Configuration"
+
+    Use the Browser SDK configuration to implicitly enable session tracking.
+
+    ```js 
+    amplitude.init(API_KEY, USER, {
+        defaultTracking: {
+            sessions: true
+        }
+    });
+    ```
+
+=== "Plugin Configuration"
+
+    Disable all default tracking by the Browser SDK. In this case, the plugin enables default session tracking.
+
+    ```js
+    amplitude.init(API_KEY, USER, {
+        defaultTracking: false
+    });
+    ```
+
+### Mask on-screen data
+
+The Session Replay SDK offers three ways to mask user input, text, and other HTML elements.
+
+| Element           | Description                                                                                                                                                                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay records asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
+| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay records masked text as a series of asterisks.                                                                 |
+| non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |
+
+### User opt-out
+
+Session Replay provides an option for opt-out configuration. This prevents Amplitude from collecting session replays when passed as part of initialization. For example:
+
+```js
+// Pass a boolean value to indicate a users opt-out status
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  optOut: true,
+}).promise;
+```
+
+### EU data residency
+
+Session Replay is available to Amplitude Customers who use the EU data center. Set the `serverZone` configuration option to `EU` during initialization. For example:
+
+```js
+// For European users, set the serverZone to "EU" 
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  serverZone: "EU",
+}).promise;
+```
+
+### Sampling rate
+
+ By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
+
+```js
+// This configuration samples 40% of all sessions
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  sampleRate: 0.4
+}).promise;
+```
+
+To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly visitors, your quota is 83% of your average visitors. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
+
+### Disable replay collection
+
+Once enabled, Session Replay runs on your site until either:
+
+- The user leaves your site
+- You call `sessionReplay.shutdown()`
+
+Call `sessionReplay.shutdown()` before a user navigates to a restricted area of your site to disable replay collection while the user is in that area. 
+
+Call `sessionReplay.init(API_KEY, {...options})` to re-enable replay collection when the return to an unrestricted area of your site.
+
+You can also use a feature flag product like Amplitude Experiment to create logic that enables or disables replay collection based on criteria like location. For example, you can create a feature flag that targets a specific user group, and add that to your initialization logic:
+
+```javascript
+import * as sessionReplay from "@amplitude/session-replay-browser";
+
+// Your existing initialization logic with Browser SDK
+amplitude.init(API_KEY);
+
+if (nonEUCountryFlagEnabled) {
+  // Create and Install Session Replay Plugin
+  const sessionReplayTracking = sessionReplayPlugin();
+  amplitude.add(sessionReplayTracking);
+}
+```
+
+## Data retention, deletion, and privacy
+
+Session replay uses existing Amplitude tools and APIs to handle privacy and deletion requests.
+
+### Retention period
+
+By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
+
+### DSAR API
+
+The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Recorded` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
+
+```json
+{
+  "amplitude_id": 123456789,
+  "app": 12345,
+  "event_time": "2020-02-15 01:00:00.123456",
+  "event_type": "first_event",
+  "server_upload_time": "2020-02-18 01:00:00.234567",
+  "device_id": "your device id",
+  "user_properties": { ... }
+  "event_properties": {
+    "[Amplitude] Session Recorded": true
+  }
+  "session_id": 1691076645125,
+}
+```
+
+### Data deletion
+
+Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-api/) to handle deletion requests. Successful deletion requests remove all session replays for the specified user.
+
+When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
+
+## Known limitations
+
+Keep the following limitations in mind as you implement Session Replay:
+
+- The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
+- Session Replay can't capture the following HTML elements:
+
+    - Canvas
+    - WebGL
+    - `<object>` tags, other than `<object type="image">`
+    - Lottie animations
+    - `<iframe>` elements from a different origin
+    - Assets that require authentication, like fonts, CSS, or images

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -210,6 +210,10 @@ Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-
 
 When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
 
+### Bot filter
+
+Session Replay uses the same [block filter](https://help.amplitude.com/hc/en-us/articles/14884769332507-Block-bot-web-traffic) available in the Amplitude app. Session Replay doesn't block traffic based on event or user properties.
+
 ## Session Replay storage
 
 Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The plugin cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -17,11 +17,10 @@ Session Replay captures changes to a page's Document Object Model (DOM), then re
 
 Use the latest version of the Session Replay Plugin above version 0.8.1. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
 
-Session Replay requires that:
+The Session Replay Plugin requires that:
 
 1. Your application is web-based.
-2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
-3. You can provide a device ID to the SDK.
+2. You can provide a device ID to the SDK.
 
 ### Supported browsers
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -260,6 +260,13 @@ Browser extensions or network security policy may block the Session Replay SDK. 
 
 As mentioned above, the default `sampleRate` for Session Replay is `0`. Update the rate to a higher number. For more information see, [Sampling rate](#sampling-rate).
 
+#### Some sessions don't include the Session Replay ID property
+
+Session replay doesn't require that all events in a session have the `[Amplitude] Session Replay ID` property, only that one event in the session has it. Reasons why `[Amplitude] Session Replay ID`  may not be present in an event include:
+
+- If you instrument an event with a source different from the source you connect to Session Replay. For example, your application may send events from a backend source, rather than the Browser SDK.
+- If events fire when the user isn't focused on the page. Session Replay pauses the SDK when user focus leaves the page. Amplitude events may still send through your provider, but `getSessionReplayProperties()` doesn't return the `[Amplitude] Session Replay ID` property. This is because Session Replay hasn't begun the capture, since the user hasn't interacted with the page. This should lead to a decrease in the amount of inactivity that a replay captures.
+
 ### Session Replay processing errors
 
 In general, replays should be available within minutes of ingestion. Delays or errors may be the result of one or more of the following:

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -162,14 +162,16 @@ Call `sessionReplay.init(API_KEY, {...options})` to re-enable replay collection 
 You can also use a feature flag product like Amplitude Experiment to create logic that enables or disables replay collection based on criteria like location. For example, you can create a feature flag that targets a specific user group, and add that to your initialization logic:
 
 ```javascript
-import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+import { sessionReplayPlugin } from "@amplitude/plugin-session-replay-browser";
 
 // Your existing initialization logic with Browser SDK
 amplitude.init(API_KEY);
 
 if (nonEUCountryFlagEnabled) {
   // Create and Install Session Replay Plugin
-  const sessionReplayTracking = sessionReplayPlugin();
+  const sessionReplayTracking = sessionReplayPlugin({
+    sampleRate: 0.5,
+  });
   amplitude.add(sessionReplayTracking);
 }
 ```

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -140,7 +140,7 @@ await sessionReplay.init(AMPLITUDE_API_KEY, {
 }).promise;
 ```
 
-To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly visitors, your quota is 83% of your average visitors. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
+To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly sessions, your quota is 83% of your average sessions. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
 
 Keep the following in mind as you consider your sample rate:
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -23,6 +23,10 @@ Session Replay requires that:
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
 
+### Supported browsers
+
+Session replay supports the same set of browsers as Amplitude's SDKs. For more information, see [Browser Compatibility](https://help.amplitude.com/hc/en-us/articles/360024709711).
+
 ## Quickstart
 
 Install the plugin with yarn or npm.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -103,8 +103,8 @@ The Session Replay SDK offers three ways to mask user input, text, and other HTM
 
 | Element           | Description                                                                                                                                                                                                                                               |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay records asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
-| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay records masked text as a series of asterisks.                                                                 |
+| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay captures asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
+| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay captures masked text as a series of asterisks.                                                                 |
 | non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |
 
 ### User opt-out
@@ -178,7 +178,7 @@ By default, Amplitude retains raw replay data for 90 days from the date of inges
 
 ### DSAR API
 
-The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Recorded` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
+The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
 
 ```json
 {

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -202,6 +202,10 @@ Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-
 
 When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
 
+## Session Replay storage
+
+Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The plugin cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
+
 ## Known limitations
 
 Keep the following limitations in mind as you implement Session Replay:

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -9,7 +9,7 @@ This article covers the installation of Session Replay using the Browser SDK plu
 
     - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
-    - Optimizing libraries for performance.
+    - Optimizing DOM processing.
 
 Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -142,6 +142,12 @@ await sessionReplay.init(AMPLITUDE_API_KEY, {
 
 To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly visitors, your quota is 83% of your average visitors. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
 
+Keep the following in mind as you consider your sample rate:
+
+- When you reach your monthly session quote, Amplitude stops capturing sessions for replay.
+- Session quotas reset on the first of every month.
+- Use sample rate to distribute your session quota over the course of a month, rather than using your full quote at the beginning of the month.
+
 ### Disable replay collection
 
 Once enabled, Session Replay runs on your site until either:
@@ -156,7 +162,7 @@ Call `sessionReplay.init(API_KEY, {...options})` to re-enable replay collection 
 You can also use a feature flag product like Amplitude Experiment to create logic that enables or disables replay collection based on criteria like location. For example, you can create a feature flag that targets a specific user group, and add that to your initialization logic:
 
 ```javascript
-import * as sessionReplay from "@amplitude/session-replay-browser";
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 
 // Your existing initialization logic with Browser SDK
 amplitude.init(API_KEY);
@@ -274,4 +280,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
-- Page instrumentation. If Session Replay isn't implemented on all pages...
+- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -11,6 +11,8 @@ This article covers the installation of Session Replay using the Browser SDK plu
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
     - Optimizing libraries for performance.
 
+Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay.
+
 ## Before you begin
 
 Use the latest version of the Session Replay Plugin above version 0.8.1. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -2,7 +2,7 @@
 title: Session Replay Browser SDK Plugin
 ---
 
-This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/docs/session-replay/sdks/standalone).
+This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/session-replay/sdks/standalone).
 
 ## Before you begin
 
@@ -208,3 +208,38 @@ Keep the following limitations in mind as you implement Session Replay:
     - Lottie animations
     - `<iframe>` elements from a different origin
     - Assets that require authentication, like fonts, CSS, or images
+
+## Troubleshooting
+
+### Session replays don't appear in Amplitude 
+
+Session replays may not appear in Amplitude due to:
+
+- Content security policy
+- Blocked JavaScript
+- Sampling
+
+#### Content security policy
+
+When you add the Session Replay script to your site, visit a page on which the Session Replay SDK is running, and open your browser's developer tools.
+
+Check for any error messages in the JavaScript console that contain the text `Content Security Policy`. For example, `Refused to connect to 'https://api-secure.amplitude.com/sessions/track' because it violates the document's Content Security Policy`.
+
+To resolve this error, update your site's content security policy to allow connection to Amplitude's APIs.
+
+#### Blocked JavaScript
+
+Browser extensions or network security policy may block the Session Replay SDK. Check your browser's developer tools to see if requests fail, and if so, add an exception for the blocked domains.
+
+#### Sampling
+
+As mentioned above, the default `sampleRate` for Session Replay is `0`. Update the rate to a higher number. For more information see, [Sampling rate](#sampling-rate).
+
+### Session Replay processing errors
+
+In general, replays should be available within minutes of ingestion. Delays or errors may be the result of one or more of the following:
+
+- Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
+- Session Replay references the wrong project.
+- Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
+- Page instrumentation. If Session Replay isn't implemented on all pages...

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -186,6 +186,8 @@ Session replay uses existing Amplitude tools and APIs to handle privacy and dele
 
 By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
 
+Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
+
 ### DSAR API
 
 The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -4,6 +4,13 @@ title: Session Replay Browser SDK Plugin
 
 This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/session-replay/sdks/standalone).
 
+!!! info "Session Replay and performance"
+    Amplitude built Session Replay to minimize impact on the performance of web pages on which it's installed by:
+
+    - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
+    - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
+    - Optimizing libraries for performance.
+
 ## Before you begin
 
 For best results, use the latest version of the Session Replay standalone SDK. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -13,7 +13,7 @@ This article covers the installation of Session Replay using the Browser SDK plu
 
 ## Before you begin
 
-For best results, use the latest version of the Session Replay standalone SDK. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
+Use the latest version of the Session Replay Plugin above version 0.8.1. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
 
 Session Replay requires that:
 
@@ -23,7 +23,7 @@ Session Replay requires that:
 
 ## Quickstart
 
-Install the standalone SDK with yarn or npm.
+Install the plugin with yarn or npm.
 
 === "npm"
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -263,6 +263,12 @@ Session Replay supports attaching to a single instance of the Amplitude SDK. If 
 
 ## Troubleshooting
 
+### Captured sessions contain limited information
+
+Session Replay requires that the Browser SDK send Session Start and Session End events, at a minimum. If you instrument events outside of the Browser SDK, Amplitude doesn't tag those events as part of the session replay. This means you can't use tools like Funnel, Segmentation, or Journeys charts to find session replays. You can find session replays with the User Sessions chart or through User Lookup.
+
+If you use a method other than the Browser SDK to instrument your events, consider using the [Session Replay Standalone SDK](/session-replay/sdks/standalone/).
+
 ### Session replays don't appear in Amplitude 
 
 Session replays may not appear in Amplitude due to:

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -190,9 +190,9 @@ The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about 
   "device_id": "your device id",
   "user_properties": { ... }
   "event_properties": {
-    "[Amplitude] Session Recorded": true
+    "[Amplitude] Session Replay ID": "cb6ade06-cbdf-4e0c-8156-32c2863379d6/1699922971244"
   }
-  "session_id": 1691076645125,
+  "session_id": 1699922971244,
 }
 ```
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -289,4 +289,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
-- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly
+- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -19,7 +19,7 @@ Use the latest version of the Session Replay Plugin above version 0.8.1. For mor
 
 Session Replay requires that:
 
-1. Your application is JavaScript-based.
+1. Your application is web-based.
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -207,3 +207,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
 - Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.
+- Replays older than the set [retention period](#retention-period) (defaults to 90 days).

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -269,6 +269,7 @@ Session replays may not appear in Amplitude due to:
 
 - Content security policy
 - Blocked JavaScript
+- No events triggered through the browser SDK in the current session
 - Sampling
 
 #### Content security policy
@@ -282,6 +283,16 @@ To resolve this error, update your site's content security policy to allow conne
 #### Blocked JavaScript
 
 Browser extensions or network security policy may block the Session Replay SDK. Check your browser's developer tools to see if requests fail, and if so, add an exception for the blocked domains.
+
+#### No events triggered through the browser SDK in the current session
+
+Session Replay requires that at least one event in the user's session has the `[Amplitude] Session Replay ID` property. If you instrument your events with a method other than the [Browser SDK](/data/sdks/browser-2/), the Browser SDK may send only the default Session Start and Session End events, which don't include this property.
+
+For local testing, you can force a Session Start event to ensure that Session Replay functions. 
+
+1. Open your browser's developer tools, and delete any cookie that begins with `AMP_`. 
+2. Close developer tools and refresh the page.
+3. In Amplitude, in the User Lookup Event Stream, you should see a Session Start event that includes the `[Amplitude] Session Replay ID` property. After processing, the Play Session button should appear for that session.
 
 #### Sampling
 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -220,6 +220,20 @@ Keep the following limitations in mind as you implement Session Replay:
     - `<iframe>` elements from a different origin
     - Assets that require authentication, like fonts, CSS, or images
 
+### Multiple Amplitude instances
+
+Session Replay supports attaching to a single instance of the Amplitude SDK. If you have more than one instance instrumented in your application, make sure to start Session Replay on the instance that most relates to your project.
+
+```html
+<script>
+  const sessionReplayTracking = window.sessionReplay.plugin();
+  const instance = window.amplitude.createInstance();
+  instance.add(sessionReplayTracking);
+  instance.init(API_KEY);
+<script>
+
+```
+
 ## Troubleshooting
 
 ### Session replays don't appear in Amplitude 

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -11,7 +11,7 @@ This article covers the installation of Session Replay using the Browser SDK plu
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
     - Optimizing libraries for performance.
 
-Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay.
+Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
 
 ## Before you begin
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -23,6 +23,10 @@ Session Replay requires that:
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
 
+### Supported browsers
+
+Session replay supports the same set of browsers as Amplitude's SDKs. For more information, see [Browser Compatibility](https://help.amplitude.com/hc/en-us/articles/360024709711).
+
 ## Quickstart
 
 Install the standalone SDK with yarn or npm.

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -11,7 +11,7 @@ This article covers the installation of Session Replay using the standalone SDK.
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
     - Optimizing libraries for performance.
 
-Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay.
+Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
 
 ## Before you begin
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -1,0 +1,3 @@
+---
+title: Session Replay Standalone SDK
+---

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -2,7 +2,7 @@
 title: Session Replay Standalone SDK
 ---
  
-This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/docs/session-replay/sdks/plugin).
+This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
 
 ## Before you begin
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -174,9 +174,9 @@ The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about 
   "device_id": "your device id",
   "user_properties": { ... }
   "event_properties": {
-    "[Amplitude] Session Recorded": true
+    "[Amplitude] Session Replay ID": "cb6ade06-cbdf-4e0c-8156-32c2863379d6/1699922971244"
   }
-  "session_id": 1691076645125,
+  "session_id": 1699922971244,
 }
 ```
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -19,7 +19,7 @@ Use the latest version of the Session Replay standalone SDK above version 0.5.0.
 
 Session Replay requires that:
 
-1. Your application is JavaScript-based.
+1. Your application is web-based.
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -4,6 +4,13 @@ title: Session Replay Standalone SDK
  
 This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
 
+!!! info "Session Replay and performance"
+    Amplitude built Session Replay to minimize impact on the performance of web pages on which it's installed by:
+
+    - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
+    - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
+    - Optimizing libraries for performance.
+
 ## Before you begin
 
 For best results, use the latest version of the Session Replay standalone SDK. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
@@ -298,7 +305,7 @@ SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
 
 ### Amplitude Classic destination (Device-mode)
 
-This version of the Amplitude destination installs the Amplitude Javascript SDK (5.2.2) on the client, and sends events directly to `api.amplitude.com`.
+This version of the Amplitude destination installs the Amplitude JavaScript SDK (5.2.2) on the client, and sends events directly to `api.amplitude.com`.
 
 The Device-mode integration tracks sessions by default, since it includes the amplitude-js SDK. The included SDK version (5.2.2) doesn't include an event for session changes. As a result, use Segment's middleware to update Session Replay when the session ID changes.
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -13,7 +13,7 @@ This article covers the installation of Session Replay using the standalone SDK.
 
 ## Before you begin
 
-For best results, use the latest version of the Session Replay standalone SDK. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
+Use the latest version of the Session Replay standalone SDK above version 0.5.0. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
 
 Session Replay requires that:
 
@@ -146,8 +146,8 @@ import * as sessionReplay from "@amplitude/session-replay-browser";
 amplitude.init(API_KEY);
 
 if (nonEUCountryFlagEnabled) {
-  // Create and Install Session Replay Plugin
-  const sessionReplayTracking = sessionReplayPlugin();
+  // Create and Install Session Replay
+  const sessionReplayTracking = sessionReplay();
   amplitude.add(sessionReplayTracking);
 }
 ```
@@ -188,11 +188,18 @@ When you delete the Amplitude project on which you use Session Replay, Amplitude
 
 ## Session Replay storage
 
-Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The plugin cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
+Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The SDK cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
 
 ## Known limitations
 
 Keep the following limitations in mind as you implement Session Replay:
+
+- Session Replay doesn't stitch together replays from a single user across multiple projects. For example:
+  
+    - You instrument your marketing site and web application as separate Amplitude projects with Session Replay enabled in each.
+    - A known user begins on the marketing site, and logs in to the web application.
+    - Amplitude captures both sessions.
+    - The replay for each session is available for view in the host project.
 
 - The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
 - Session Replay can't capture the following HTML elements:

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -173,6 +173,8 @@ Session replay uses existing Amplitude tools and APIs to handle privacy and dele
 
 By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
 
+Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
+
 ### DSAR API
 
 The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -87,8 +87,8 @@ The Session Replay SDK offers three ways to mask user input, text, and other HTM
 
 | Element           | Description                                                                                                                                                                                                                                               |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay records asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
-| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay records masked text as a series of asterisks.                                                                 |
+| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay captures asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
+| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay captures masked text as a series of asterisks.                                                                 |
 | non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |
 
 ### User opt-out

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -197,6 +197,10 @@ Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-
 
 When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
 
+### Bot filter
+
+Session Replay uses the same [block filter](https://help.amplitude.com/hc/en-us/articles/14884769332507-Block-bot-web-traffic) available in the Amplitude app. Session Replay doesn't block traffic based on event or user properties.
+
 ## Session Replay storage
 
 Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The SDK cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -124,7 +124,13 @@ await sessionReplay.init(AMPLITUDE_API_KEY, {
 }).promise;
 ```
 
-To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly visitors, your quota is 83% of your average visitors. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
+To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly sessions, your quota is 83% of your average sessions. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
+
+Keep the following in mind as you consider your sample rate:
+
+- When you reach your monthly session quote, Amplitude stops capturing sessions for replay.
+- Session quotas reset on the first of every month.
+- Use sample rate to distribute your session quota over the course of a month, rather than using your full quote at the beginning of the month.
 
 ### Disable replay collection
 
@@ -140,14 +146,14 @@ Call `sessionReplay.init(API_KEY, {...options})` to re-enable replay collection 
 You can also use a feature flag product like Amplitude Experiment to create logic that enables or disables replay collection based on criteria like location. For example, you can create a feature flag that targets a specific user group, and add that to your initialization logic:
 
 ```javascript
-import * as sessionReplay from "@amplitude/session-replay-browser";
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 
 // Your existing initialization logic with Browser SDK
 amplitude.init(API_KEY);
 
 if (nonEUCountryFlagEnabled) {
-  // Create and Install Session Replay
-  const sessionReplayTracking = sessionReplay();
+  // Create and Install Session Replay Plugin
+  const sessionReplayTracking = sessionReplayPlugin();
   amplitude.add(sessionReplayTracking);
 }
 ```
@@ -206,7 +212,7 @@ Keep the following limitations in mind as you implement Session Replay:
 
     - Canvas
     - WebGL
-    - `<object>` tags, other than `<object type="image">`
+    - `<object>` tags including plugins like Flash, Silverlight, or Java. Session replay supports `<object type="image">`
     - Lottie animations
     - `<iframe>` elements from a different origin
     - Assets that require authentication, like fonts, CSS, or images
@@ -257,13 +263,13 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
-- Page instrumentation. If Session Replay isn't implemented on all pages...
+- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly
 
 ## Use Session Replay with Segment analytics
 
 Session Replay supports other analytics providers. Follow the information below to add Session Replay to an existing Segment-instrumented site.
 
-- [Amplitide (Actions)](#amplitude-actions-destination)
+- [Amplitude (Actions)](#amplitude-actions-destination)
 - Amplitude Classic (Cloud-mode)
 - Amplitude Classic (Device-mode)
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -162,7 +162,7 @@ By default, Amplitude retains raw replay data for 90 days from the date of inges
 
 ### DSAR API
 
-The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Recorded` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
+The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
 
 ```json
 {
@@ -291,7 +291,7 @@ segmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
 
 // Add middleware to always add session replay properties to track calls
 SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
-  const sessionReplayProperties = sessionReplay.getSessionRecordingProperties();
+  const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
   if (payload.type() === "track") {
     payload.obj.properties = {
       ...payload.obj.properties,
@@ -351,7 +351,7 @@ SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
 
 // Add middleware to always add session replay properties to track calls
 SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
-  const sessionReplayProperties = sessionReplay.getSessionRecordingProperties();
+  const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
   if (payload.type() === "track") {
     payload.obj.properties = {
       ...payload.obj.properties,

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -4,14 +4,7 @@ title: Session Replay Standalone SDK
  
 This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
 
-!!! info "Session Replay and performance"
-    Amplitude built Session Replay to minimize impact on the performance of web pages on which it's installed by:
-
-    - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
-    - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
-    - Optimizing DOM processing.
-
-Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
+--8<-- "includes/session-replay/performance.md"
 
 ## Before you begin
 
@@ -23,9 +16,7 @@ Session Replay Standalone SDK requires that:
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
 
-### Supported browsers
-
-Session replay supports the same set of browsers as Amplitude's SDKs. For more information, see [Browser Compatibility](https://help.amplitude.com/hc/en-us/articles/360024709711).
+--8<-- "includes/session-replay/browsers.md"
 
 ## Quickstart
 
@@ -87,56 +78,13 @@ Pass the following configuration options when you initialize the Session Replay 
 | `loggerProvider`  | `Logger`  | No       | `Logger`        | Sets a custom `loggerProvider` class from the Logger to emit log messages to desired destination.                                                                                                                                                                                                                                                                                                                                             |
 | `serverZone`      | `string`  | No       | `US`            | EU or US. Sets the Amplitude server zone. Set this to EU for Amplitude projects created in EU data center.                                                                                                                                                                                                                                                                                                                                  |
 
-### Mask on-screen data
+--8<-- "includes/session-replay/mask-onscreen-data.md"
 
-The Session Replay SDK offers three ways to mask user input, text, and other HTML elements.
+--8<-- "includes/session-replay/user-opt-out.md"
 
-| Element           | Description                                                                                                                                                                                                                                               |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay captures asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
-| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay captures masked text as a series of asterisks.                                                                 |
-| non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |
+--8<-- "includes/session-replay/eu-data-residency.md"
 
-### User opt-out
-
-Session Replay provides an option for opt-out configuration. This prevents Amplitude from collecting session replays when passed as part of initialization. For example:
-
-```js
-// Pass a boolean value to indicate a users opt-out status
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  optOut: true,
-}).promise;
-```
-
-### EU data residency
-
-Session Replay is available to Amplitude Customers who use the EU data center. Set the `serverZone` configuration option to `EU` during initialization. For example:
-
-```js
-// For European users, set the serverZone to "EU" 
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  serverZone: "EU",
-}).promise;
-```
-
-### Sampling rate
-
-By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
-
-```js
-// This configuration samples 40% of all sessions
-await sessionReplay.init(AMPLITUDE_API_KEY, {
-  sampleRate: 0.4
-}).promise;
-```
-
-To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly sessions, your quota is 83% of your average sessions. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
-
-Keep the following in mind as you consider your sample rate:
-
-- When you reach your monthly session quote, Amplitude stops capturing sessions for replay.
-- Session quotas reset on the first of every month.
-- Use sample rate to distribute your session quota over the course of a month, rather than using your full quote at the beginning of the month.
+--8<-- "includes/session-replay/sampling-rate.md"
 
 ### Disable replay collection
 
@@ -169,76 +117,11 @@ if (nonEUCountryFlagEnabled) {
 }
 ```
 
-## Data retention, deletion, and privacy
+--8<-- "includes/session-replay/data-retention.md"
 
-Session replay uses existing Amplitude tools and APIs to handle privacy and deletion requests.
+--8<-- "includes/session-replay/replay-storage.md"
 
-### Retention period
-
-By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
-
-Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
-
-### DSAR API
-
-The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
-
-```json
-{
-  "amplitude_id": 123456789,
-  "app": 12345,
-  "event_time": "2020-02-15 01:00:00.123456",
-  "event_type": "first_event",
-  "server_upload_time": "2020-02-18 01:00:00.234567",
-  "device_id": "your device id",
-  "user_properties": { ... }
-  "event_properties": {
-    "[Amplitude] Session Replay ID": "cb6ade06-cbdf-4e0c-8156-32c2863379d6/1699922971244"
-  }
-  "session_id": 1699922971244,
-}
-```
-
-### Data deletion
-
-Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-api/) to handle deletion requests. Successful deletion requests remove all session replays for the specified user.
-
-When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
-
-### Bot filter
-
-Session Replay uses the same [block filter](https://help.amplitude.com/hc/en-us/articles/14884769332507-Block-bot-web-traffic) available in the Amplitude app. Session Replay doesn't block traffic based on event or user properties.
-
-## Session Replay storage
-
-Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The SDK cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
-
-## Known limitations
-
-Keep the following limitations in mind as you implement Session Replay:
-
-- Session Replay doesn't stitch together replays from a single user across multiple projects. For example:
-  
-    - You instrument your marketing site and web application as separate Amplitude projects with Session Replay enabled in each.
-    - A known user begins on the marketing site, and logs in to the web application.
-    - Amplitude captures both sessions.
-    - The replay for each session is available for view in the host project.
-
-- The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
-- Session Replay can't capture the following HTML elements:
-
-    - Canvas
-    - WebGL
-    - `<object>` tags including plugins like Flash, Silverlight, or Java. Session replay supports `<object type="image">`
-    - Lottie animations
-    - `<iframe>` elements from a different origin
-    - Assets that require authentication, like fonts, CSS, or images
-
-<!-- 
-## Go-live checklist
-
-TBD 
--->
+--8<-- "includes/session-replay/known-limitations.md"
 
 ## Troubleshooting
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -164,6 +164,7 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
 - Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.
+- Replays older than the set [retention period](#retention-period) (defaults to 90 days).
 
 ## Use Session Replay with Segment analytics
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -146,15 +146,20 @@ Call `sessionReplay.init(API_KEY, {...options})` to re-enable replay collection 
 You can also use a feature flag product like Amplitude Experiment to create logic that enables or disables replay collection based on criteria like location. For example, you can create a feature flag that targets a specific user group, and add that to your initialization logic:
 
 ```javascript
-import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+import * as sessionReplay from "@amplitude/session-replay-browser";
+import 3rdPartyAnalytics from 'example'
 
-// Your existing initialization logic with Browser SDK
-amplitude.init(API_KEY);
+const AMPLITUDE_API_KEY = <...>
+sessionReplay.init(AMPLITUDE_API_KEY, {
+  deviceId: <string>,
+  sessionId: <number>,
+  optOut: <boolean>,
+  sampleRate: <number>
+})
 
 if (nonEUCountryFlagEnabled) {
-  // Create and Install Session Replay Plugin
-  const sessionReplayTracking = sessionReplayPlugin();
-  amplitude.add(sessionReplayTracking);
+  const sessionReplayProperties = sessionReplay.getSessionReplayProperties();
+  3rdPartyAnalytics.track('event', {...eventProperties, ...sessionReplayProperties})
 }
 ```
 
@@ -270,8 +275,8 @@ In general, replays should be available within minutes of ingestion. Delays or e
 Session Replay supports other analytics providers. Follow the information below to add Session Replay to an existing Segment-instrumented site.
 
 - [Amplitude (Actions)](#amplitude-actions-destination)
-- Amplitude Classic (Cloud-mode)
-- Amplitude Classic (Device-mode)
+- [Amplitude Classic (Cloud-mode)](#amplitude-classic-destination-cloud-mode)
+- [Amplitude Classic (Device-mode)](#amplitude-classic-destination-device-mode)
 
 ### Amplitude (Actions) destination
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -115,7 +115,7 @@ await sessionReplay.init(AMPLITUDE_API_KEY, {
 
 ### Sampling rate
 
- By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
+By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
 
 ```js
 // This configuration samples 40% of all sessions
@@ -235,6 +235,13 @@ Browser extensions or network security policy may block the Session Replay SDK. 
 #### Sampling
 
 As mentioned above, the default `sampleRate` for Session Replay is `0`. Update the rate to a higher number. For more information see, [Sampling rate](#sampling-rate).
+
+#### Some sessions don't include the Session Replay ID property
+
+Session replay doesn't require that all events in a session have the `[Amplitude] Session Replay ID` property, only that one event in the session has it. Reasons why `[Amplitude] Session Replay ID`  may not be present in an event include:
+
+- If you instrument an event with a source different from the source you connect to Session Replay. For example, your application may send events from a backend source, rather than the Browser SDK.
+- If events fire when the user isn't focused on the page. Session Replay pauses the SDK when user focus leaves the page. Amplitude events may still send through your provider, but `getSessionReplayProperties()` doesn't return the `[Amplitude] Session Replay ID` property. This is because Session Replay hasn't begun the capture, since the user hasn't interacted with the page. This should lead to a decrease in the amount of inactivity that a replay captures.
 
 ### Session Replay processing errors
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -2,7 +2,7 @@
 title: Session Replay Standalone SDK
 ---
  
-This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, you can use the [Session Replay Browser SDK Plugin](/docs/session-replay/sdks/plugin).
+This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/docs/session-replay/sdks/plugin).
 
 ## Before you begin
 
@@ -232,4 +232,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
-- Page instrumentation. If Session Replay isn't implemented on all pages
+- Page instrumentation. If Session Replay isn't implemented on all pages...

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -11,6 +11,8 @@ This article covers the installation of Session Replay using the standalone SDK.
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
     - Optimizing libraries for performance.
 
+Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay.
+
 ## Before you begin
 
 Use the latest version of the Session Replay standalone SDK above version 0.5.0. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -233,3 +233,178 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
 - Page instrumentation. If Session Replay isn't implemented on all pages...
+
+## Use Session Replay with Segment analytics
+
+Session Replay supports other analytics providers. Follow the information below to add Session Replay to an existing Segment-instrumented site.
+
+- [Amplitide (Actions)](#amplitude-actions-destination)
+- Amplitude Classic (Cloud-mode)
+- Amplitude Classic (Device-mode)
+
+### Amplitude (Actions) destination
+
+Amplitude (Actions) tracks sessions automatically. When a user starts a new session, Amplitude sets an `analytics_session_id` cookie on the users browser. Configure your implementation to listen for changes in value to `analytics_session_id`, which you can do with Segment's [Source Middleware](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/middleware/).
+
+This code snippet shows how to configure Session Replay with Segment's Amplitude (Actions) integration, and update the session ID when `analytics_session_id` changes.
+
+```javascript
+import * as sessionReplay from "@amplitude/session-replay-browser";
+import { AnalyticsBrowser } from "@segment/analytics-next";
+
+const segmentAnalytics = AnalyticsBrowser.load({
+  writeKey: "segment-key",
+});
+
+const AMPLITUDE_API_KEY = 'api-key' // must match that saved with Segment
+
+const getStoredSessionId = () => {
+ return cookie.get("amp_session_id") || 0;
+}
+
+const user = await segmentAnalytics.user();
+const storedSessionId = getStoredSessionId();
+await sessionReplay.init(AMPLITUDE_API_KEY, { 
+  sessionId: storedSessionId,
+  deviceId: user.anonymousId()
+}).promise;
+
+// Add middleware to check if the session id has changed, 
+// and update the session replay instance
+segmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
+  const storedSessionId = getStoredSessionId();
+  const nextSessionId = payload.obj.integrations['Actions Amplitude'].session_id || 0
+
+  if (storedSessionId < nextSessionId) {
+    cookie.set("amp_session_id", nextSessionId);
+    sessionReplay.setSessionId(nextSessionId);
+  }
+  next(payload);
+});
+
+// Add middleware to always add session replay properties to track calls
+SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
+  const sessionReplayProperties = sessionReplay.getSessionRecordingProperties();
+  if (payload.type() === "track") {
+    payload.obj.properties = {
+      ...payload.obj.properties,
+      ...sessionReplayProperties,
+    };
+  }
+  
+  next(payload);
+});
+```
+
+### Amplitude Classic destination (Device-mode)
+
+This version of the Amplitude destination installs the Amplitude Javascript SDK (5.2.2) on the client, and sends events directly to `api.amplitude.com`.
+
+The Device-mode integration tracks sessions by default, since it includes the amplitude-js SDK. The included SDK version (5.2.2) doesn't include an event for session changes. As a result, use Segment's middleware to update Session Replay when the session ID changes.
+
+```javascript
+import * as sessionReplay from "@amplitude/session-replay-browser";
+import { AnalyticsBrowser } from "@segment/analytics-next";
+
+const segmentAnalytics = AnalyticsBrowser.load({
+  writeKey: "segment-key",
+});
+
+const AMPLITUDE_API_KEY = 'api-key' // must match that saved with Segment
+
+const getAmpSessionId = () => {
+  const sessionId = window.amplitude.getInstance().getSessionId();
+  cookie.set("amp_session_id", sessionId);
+  return sessionId;
+};
+
+// Wait for the amplitude-js SDK to initialize,
+// then initialize session replay with the correct device id and session id
+window.amplitude.getInstance().onInit(() => {
+  const sessionId = getAmpSessionId();
+  sessionReplay.init(AMPLITUDE_API_KEY, {
+    deviceId: window.amplitude.getInstance().options.deviceId,
+    sessionId: getAmpSessionId(),
+  });
+});
+
+
+// Add middleware to check if the session id has changed, 
+// and update the session replay instance
+SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
+  const nextSessionId = window.amplitude.getInstance().getSessionId();
+  const storedSessionId = cookie.get("amp_session_id") || 0;
+
+  if (storedSessionId < nextSessionId) {
+    cookie.set("amp_session_id", nextSessionId);
+    sessionReplay.setSessionId(nextSessionId);
+  }
+  next(payload);
+});
+
+// Add middleware to always add session replay properties to track calls
+SegmentAnalytics.addSourceMiddleware(({ payload, next, integrations }) => {
+  const sessionReplayProperties = sessionReplay.getSessionRecordingProperties();
+  if (payload.type() === "track") {
+    payload.obj.properties = {
+      ...payload.obj.properties,
+      ...sessionReplayProperties,
+    };
+  }
+  
+  next(payload);
+});
+```
+
+### Amplitude Classic destination (Cloud-mode)
+
+This version of the Amplitude destination sends events to Segment's backend, which forwards them to Amplitude. The Cloud-mode destination doesn't track sessions by default. To overcome this, use the Browser SDK as a shell to manage sessions, and use Session Replay as a plugin, as shown below.
+
+```javascript
+import { sessionReplayPlugin } from "@amplitude/plugin-session-replay-browser";
+import { AnalyticsBrowser } from "@segment/analytics-next";
+
+const segmentAnalytics = AnalyticsBrowser.load({
+  writeKey: "segment-key",
+});
+
+// A plugin must be added so that events sent through Segment will have
+// session replay properties and the correct session id
+const segmentPlugin: () => Plugin = () => {
+  return {
+    name: 'segment',
+    type: 'enrichment',
+    execute: async (event) => {
+      const properties = event.event_properties || {};
+
+      segmentAnalytics.track(event.event_type, properties, {
+        integrations: {
+          Amplitude: {
+            session_id: amplitude.getSessionId(),
+          },
+        },
+      });
+      return Promise.resolve(event);
+    }
+  }
+}
+
+const AMPLITUDE_API_KEY = 'api-key' // must match that saved with Segment
+
+// Add the session replay plugin first, then the segment plugin
+await amplitude.add(sessionReplayPlugin()).promise;
+await amplitude.add(segmentPlugin()).promise;
+
+const user = await segmentAnalytics.user();
+await amplitude.init(AMPLITUDE_API_KEY, { 
+  instanceName: 'session-replay',
+  sessionTimeout: Number.MAX_SAFE_INTEGER,
+  defaultTracking: false,
+  deviceId: user.anonymousId()
+}).promise;
+amplitude.remove('amplitude');
+
+// Events must be tracked through the shell Browser SDK to properly attach
+// session replay properties
+amplitude.track('event name')
+```

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -9,7 +9,7 @@ This article covers the installation of Session Replay using the standalone SDK.
 
     - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
     - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
-    - Optimizing libraries for performance.
+    - Optimizing DOM processing.
 
 Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -17,7 +17,7 @@ Session Replay captures changes to a page's Document Object Model (DOM), then re
 
 Use the latest version of the Session Replay standalone SDK above version 0.5.0. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
 
-Session Replay requires that:
+Session Replay Standalone SDK requires that:
 
 1. Your application is web-based.
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -268,7 +268,7 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Mismatching API keys or Device IDs. This can happen if Session Replay and standard event instrumentation use different API keys or Device IDs.
 - Session Replay references the wrong project.
 - Short sessions. If a users bounces within a few seconds of initialization, the SDK may not have time to upload replay data.
-- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly
+- Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.
 
 ## Use Session Replay with Segment analytics
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -186,6 +186,10 @@ Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-
 
 When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
 
+## Session Replay storage
+
+Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The plugin cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
+
 ## Known limitations
 
 Keep the following limitations in mind as you implement Session Replay:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -633,3 +633,9 @@ table code {
 .DocSearch-Hit-source {
   font-size: .5rem;
 }
+
+/* Code sample highlight overrides */
+
+.highlight .c1 {
+  color: #282828a6
+}

--- a/includes/session-replay/browsers.md
+++ b/includes/session-replay/browsers.md
@@ -1,0 +1,3 @@
+### Supported browsers
+
+Session replay supports the same set of browsers as Amplitude's SDKs. For more information, see [Browser Compatibility](https://help.amplitude.com/hc/en-us/articles/360024709711).

--- a/includes/session-replay/data-retention.md
+++ b/includes/session-replay/data-retention.md
@@ -1,0 +1,39 @@
+## Data retention, deletion, and privacy
+
+Session replay uses existing Amplitude tools and APIs to handle privacy and deletion requests.
+
+### Retention period
+
+By default, Amplitude retains raw replay data for 90 days from the date of ingestion. If your use case requires a more strict policy, Amplitude can set the value to 30 days by request.
+
+Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
+
+### DSAR API
+
+The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.
+
+```json
+{
+  "amplitude_id": 123456789,
+  "app": 12345,
+  "event_time": "2020-02-15 01:00:00.123456",
+  "event_type": "first_event",
+  "server_upload_time": "2020-02-18 01:00:00.234567",
+  "device_id": "your device id",
+  "user_properties": { ... }
+  "event_properties": {
+    "[Amplitude] Session Replay ID": "cb6ade06-cbdf-4e0c-8156-32c2863379d6/1699922971244"
+  }
+  "session_id": 1699922971244,
+}
+```
+
+### Data deletion
+
+Session Replay uses Amplitude's [User Privacy API](/analytics/apis/user-privacy-api/) to handle deletion requests. Successful deletion requests remove all session replays for the specified user.
+
+When you delete the Amplitude project on which you use Session Replay, Amplitude deletes that replay data.
+
+### Bot filter
+
+Session Replay uses the same [block filter](https://help.amplitude.com/hc/en-us/articles/14884769332507-Block-bot-web-traffic) available in the Amplitude app. Session Replay doesn't block traffic based on event or user properties.

--- a/includes/session-replay/data-retention.md
+++ b/includes/session-replay/data-retention.md
@@ -8,6 +8,8 @@ By default, Amplitude retains raw replay data for 90 days from the date of inges
 
 Changes to the retention period impact replays ingested after the change. Sessions captured and ingested before a retention period change retain the previous retention period.
 
+Replays that are outside of the retention period aren't viewable in Amplitude.
+
 ### DSAR API
 
 The Amplitude [DSAR API](/analytics/apis/ccpa-dsar-api/) returns metadata about session replays, but not the raw replay data. All events that are part of a session replay include a `[Amplitude] Session Replay ID` event property. This event provides information about the sessions collected for replay for the user, and includes all metadata collected with each event.

--- a/includes/session-replay/eu-data-residency.md
+++ b/includes/session-replay/eu-data-residency.md
@@ -1,0 +1,10 @@
+### EU data residency
+
+Session Replay is available to Amplitude Customers who use the EU data center. Set the `serverZone` configuration option to `EU` during initialization. For example:
+
+```js
+// For European users, set the serverZone to "EU" 
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  serverZone: "EU",
+}).promise;
+```

--- a/includes/session-replay/known-limitations.md
+++ b/includes/session-replay/known-limitations.md
@@ -1,0 +1,20 @@
+## Known limitations
+
+Keep the following limitations in mind as you implement Session Replay:
+
+- Session Replay doesn't stitch together replays from a single user across multiple projects. For example:
+  
+    - You instrument your marketing site and web application as separate Amplitude projects with Session Replay enabled in each.
+    - A known user begins on the marketing site, and logs in to the web application.
+    - Amplitude captures both sessions.
+    - The replay for each session is available for view in the host project.
+
+- The User Sessions chart doesn't show session replays if your organization uses a custom session definition.
+- Session Replay can't capture the following HTML elements:
+
+    - Canvas
+    - WebGL
+    - `<object>` tags including plugins like Flash, Silverlight, or Java. Session replay supports `<object type="image">`
+    - Lottie animations
+    - `<iframe>` elements from a different origin
+    - Assets that require authentication, like fonts, CSS, or images

--- a/includes/session-replay/mask-onscreen-data.md
+++ b/includes/session-replay/mask-onscreen-data.md
@@ -1,0 +1,9 @@
+### Mask on-screen data
+
+The Session Replay SDK offers three ways to mask user input, text, and other HTML elements.
+
+| Element           | Description                                                                                                                                                                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<input>`         | Session Replay masks all text input fields by default. When a users enters text into an input field, Session Replay captures asterisks in place of text. To *unmask* a text input, add the class `.amp-unmask`. For example: `<input class="amp-unmask">`. |
+| text              | To mask text within non-input elements, add the class `.amp-mask`. For example, `<p class="amp-mask">Text</p>`. When masked, Session Replay captures masked text as a series of asterisks.                                                                 |
+| non-text elements | To block a non-text element, add the class `.amp-block`. For example, `<div class="amp-block"></div>`. Session Replay replaces blocked elements with a placeholder of the same dimensions.                                                                |

--- a/includes/session-replay/performance.md
+++ b/includes/session-replay/performance.md
@@ -1,0 +1,8 @@
+!!! info "Session Replay and performance"
+    Amplitude built Session Replay to minimize impact on the performance of web pages on which it's installed by:
+
+    - Asynchronously capturing and processing replay data, to avoid blocking the main user interface thread.
+    - Using batching and lightweight compression to reduce the number of network connections and bandwidth.
+    - Optimizing DOM processing.
+
+Session Replay captures changes to a page's Document Object Model (DOM), then replays these changes to build a video-like replay. For example, at the start of a session, Session Replay captures a full snapshot of the page's DOM. As the user interacts with the page, Session Replay captures each change to the DOM as a diff. When you watch the replay of a session, Session Replay applies each diff back to the original DOM in sequential order, to construct the replay. Session replays have no maximum length.

--- a/includes/session-replay/replay-storage.md
+++ b/includes/session-replay/replay-storage.md
@@ -1,3 +1,5 @@
 ## Session Replay storage
 
 Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The SDK cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.
+
+If a user opts out of all cookies on your site, use the `optOut` configuration option to disable replay collection for that user.

--- a/includes/session-replay/replay-storage.md
+++ b/includes/session-replay/replay-storage.md
@@ -1,0 +1,3 @@
+## Session Replay storage
+
+Session Replay doesn't set cookies on the user's browser. Instead, it relies on a browser storage option called [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API). This option enables continuous replay collection during a session in which the user navigates browser tabs or closes and reopens a tab. The SDK cleans up the data it stores in IndexedDB and shouldn't impact the user's disk space.

--- a/includes/session-replay/sampling-rate.md
+++ b/includes/session-replay/sampling-rate.md
@@ -1,0 +1,18 @@
+### Sampling rate
+
+ By default, Session Replay captures 0% of sessions for replay. Use the `sampleRate` configuration option to set the percentage of total sessions that Session Replay captures. For example:
+
+```js
+// This configuration samples 40% of all sessions
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  sampleRate: 0.4
+}).promise;
+```
+
+To set the `sampleRate` consider the monthly quota on your Session Replay plan. For example, if your monthly quota is 2,500,000 sessions, and you average 3,000,000 monthly sessions, your quota is 83% of your average sessions. In this case, to ensure sampling lasts through the month, set `sampleRate` to `.83` or lower.
+
+Keep the following in mind as you consider your sample rate:
+
+- When you reach your monthly session quota, Amplitude stops capturing sessions for replay.
+- Session quotas reset on the first of every month.
+- Use sample rate to distribute your session quota over the course of a month, rather than using your full quota at the beginning of the month.

--- a/includes/session-replay/user-opt-out.md
+++ b/includes/session-replay/user-opt-out.md
@@ -1,0 +1,10 @@
+### User opt-out
+
+Session Replay provides an option for opt-out configuration. This prevents Amplitude from collecting session replays when passed as part of initialization. For example:
+
+```js
+// Pass a boolean value to indicate a users opt-out status
+await sessionReplay.init(AMPLITUDE_API_KEY, {
+  optOut: true,
+}).promise;
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -434,6 +434,12 @@ nav:
           - Flags: experiment/apis/management-api/flags.md
           - Experiments: experiment/apis/management-api/experiments.md
           - Deployments: experiment/apis/management-api/deployments.md
+  - Session Replay:
+      - session-replay/index.md
+      - Overview: session-replay/index.md
+      - SDKs:
+        - Browser SDK Plugin: session-replay/sdks/plugin.md
+        - Standalone SDK: session-replay/sdks/standalone.md
 - Guides:
   - guides/index.md
   - Accounts Guide: guides/accounts-instrumentation-guide.md


### PR DESCRIPTION
- Init and stub out content
- Update to standalone doc, css, and vale rule
- quick grammar update
- Plugin SDK doc

# Amplitude Developer Docs PR


## Description

Docs (Standalon and Plugin) for instrumenting Session Replay
## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [x] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
