### PR TITLE
Add link to google service account docs

### DIFF
--- a/docs/data/destinations/google-ads-event-streaming.md
+++ b/docs/data/destinations/google-ads-event-streaming.md
@@ -9,7 +9,7 @@ Amplitude Data's Google Ads integration enables you to stream your Amplitude eve
 ## Considerations
 
 - You must enable this integration in each Amplitude project you want to use it in.
-- Amplitude sends custom events using Amplitude event_type as event name.
+- Amplitude sends custom events using Amplitude `event_type` as event name.
 
 ## Setup
 
@@ -17,9 +17,9 @@ Amplitude Data's Google Ads integration enables you to stream your Amplitude eve
 
 To set up event streaming to Google Ads, you need the following:
 
-- A `Google Ads Customer ID`
-- A `Google Ads Conversion Action ID`
-- A `Google Cloud Service Account`
+- A Google Ads Customer ID
+- A Google Ads Conversion Action ID
+- A [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts-create)
 
 ### Amplitude setup
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Adds a link to Google's documentation about creating service accounts. Addresses #68. Will not add instructions directly, as we don't 
want to maintain documentation for another company's product.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
