### PR TITLE
Update Experiment PHP docs with assignment tracking

### DIFF
--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -203,11 +203,31 @@ You can configure the SDK client on initialization.
 
 ???config "Configuration Options"
 
+    **LocalEvaluationConfig**
+
     | <div class="big-column">Name</div> | Description | Default Value |
     | --- | --- | --- |
     | `debug` | Set to `true` to enable debug logging. | `false` |
     | `serverUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `bootstrap` | Bootstrap the client with an array of flag key to flag configuration | `[]` |
+
+    **AssignmentConfig**
+
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `apiKey` | The analytics API key and NOT the experiment deployment key | *required* |
+    | `cacheCapacity` | The maximum number of assignments stored in the assignment cache | `65536` |
+    | `amplitudeConfig` | Options to configure the underlying Amplitude Analytics SDK used to track assignment events | default `AmplitudeConfig` |
+
+    **AmplitudeConfig**
+
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `flushQueueSize` | Events wait in the buffer and are sent in a batch. The buffer is flushed when the number of events reaches `flushQueueSize`. | `200` |
+    | `flushMaxRetries` | The number of times the client retries an event when the request returns an error. | `12` |
+    | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
+    | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `None`, then `server_zone` and `use_batch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
+    | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `False` |
 
 !!!info "EU Data Center"
     If you use Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
@@ -230,6 +250,10 @@ $client->start()->wait();
 ### Evaluate
 
 Executes the [evaluation logic](../general/evaluation/implementation.md) using the flags fetched on [`start()`](#start). Give `evaluate()` a user object argument. Optionally pass an array of flag keys if you require only a specific subset of required flag variants.
+
+
+!!!tip "Automatic Assignment Tracking"
+    Set [`assignmentConfig`](#configuration_1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
 
 ```php
 evaluate(User $user, array $flagKeys = []): array

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -216,9 +216,9 @@ You can configure the SDK client on initialization.
 
     | <div class="big-column">Name</div> | Description | Default Value |
     | --- | --- | --- |
-    | `apiKey` | The analytics API key and NOT the experiment deployment key | *required* |
-    | `cacheCapacity` | The maximum number of assignments stored in the assignment cache | `65536` |
-    | `flushQueueSize` | Events wait in the buffer and are sent in a batch. The buffer is flushed when the number of events reaches `flushQueueSize`. | `200` |
+    | `apiKey` | The analytics API key. Not to be confused with the experiment deployment key. | *required* |
+    | `cacheCapacity` | The maximum number of assignments stored in the assignment cache. | `65536` |
+    | `flushQueueSize` | Events wait in the buffer and are sent in a batch. Experiment flushes the buffer when the number of events reaches the `flushQueueSize`. | `200` |
     | `flushMaxRetries` | The number of times the client retries an event when the request returns an error. | `12` |
     | `minIdLength` | The minimum length of `userId` and `deviceId`. | `5` |
     | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
@@ -248,7 +248,7 @@ $client->start()->wait();
 Executes the [evaluation logic](../general/evaluation/implementation.md) using the flags fetched on [`start()`](#start). Give `evaluate()` a user object argument. Optionally pass an array of flag keys if you require only a specific subset of required flag variants.
 
 !!!tip "Automatic Assignment Tracking"
-    Set [`assignmentConfig`](#configuration_1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
+    Set [`assignmentConfig`](#configuration_1) to automatically track an assignment event to Amplitude when you call `evaluate()`.
 
 ```php
 evaluate(User $user, array $flagKeys = []): array

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -210,6 +210,7 @@ You can configure the SDK client on initialization.
     | `debug` | Set to `true` to enable debug logging. | `false` |
     | `serverUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `bootstrap` | Bootstrap the client with an array of flag key to flag configuration | `[]` |
+    | `assignmentConfig` | Configuration for automatically tracking assignment events after an evaluation. | `null` |
 
     **AssignmentConfig**
 

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -217,17 +217,11 @@ You can configure the SDK client on initialization.
     | --- | --- | --- |
     | `apiKey` | The analytics API key and NOT the experiment deployment key | *required* |
     | `cacheCapacity` | The maximum number of assignments stored in the assignment cache | `65536` |
-    | `amplitudeConfig` | Options to configure the underlying Amplitude Analytics SDK used to track assignment events | default `AmplitudeConfig` |
-
-    **AmplitudeConfig**
-
-    | <div class="big-column">Name</div> | Description | Default Value |
-    | --- | --- | --- |
     | `flushQueueSize` | Events wait in the buffer and are sent in a batch. The buffer is flushed when the number of events reaches `flushQueueSize`. | `200` |
     | `flushMaxRetries` | The number of times the client retries an event when the request returns an error. | `12` |
     | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
-    | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `None`, then `server_zone` and `use_batch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
-    | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `False` |
+    | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `null`, then `serverZone` and `useBatch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
+    | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `false` |
 
 !!!info "EU Data Center"
     If you use Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -219,6 +219,7 @@ You can configure the SDK client on initialization.
     | `cacheCapacity` | The maximum number of assignments stored in the assignment cache | `65536` |
     | `flushQueueSize` | Events wait in the buffer and are sent in a batch. The buffer is flushed when the number of events reaches `flushQueueSize`. | `200` |
     | `flushMaxRetries` | The number of times the client retries an event when the request returns an error. | `12` |
+    | `minIdLength` | The minimum length of `userId` and `deviceId`. | `5` |
     | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
     | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `null`, then `serverZone` and `useBatch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
     | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `false` |

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -246,7 +246,6 @@ $client->start()->wait();
 
 Executes the [evaluation logic](../general/evaluation/implementation.md) using the flags fetched on [`start()`](#start). Give `evaluate()` a user object argument. Optionally pass an array of flag keys if you require only a specific subset of required flag variants.
 
-
 !!!tip "Automatic Assignment Tracking"
     Set [`assignmentConfig`](#configuration_1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update Experiment PHP docs with assignment tracking

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
