### PR TITLE
AMP-88309 Add additional property docs to Snowflake/BigQuery/S3/GCS

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -289,6 +289,8 @@ After you have all the fields needed for the transformation, you can save it. Yo
 
 You can include more fields by clicking the **Add Mapping** button. Here Amplitude supports 4 kinds of mappings: Event properties, User Properties, Group Properties and Additional Properties. 
 
+All supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored. 
+
 After you have added all the fields you wish to bring into Amplitude, you can view samples of this configuration in the Data Preview section. Data Preview automatically updates as you include or remove fields and properties. In Data Preview, you can look at a few sample records based on the source records along with how that data is imported into Amplitude. This ensures that you are bringing in all the data points you need into Amplitude. You can look at 10 different sample source records and their corresponding Amplitude events.
 
 ![Screenshot of a converter preview](../../assets/images/converter-preview.png)

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -289,7 +289,7 @@ After you have all the fields needed for the transformation, you can save it. Yo
 
 You can include more fields by clicking the **Add Mapping** button. Here Amplitude supports 4 kinds of mappings: Event properties, User Properties, Group Properties and Additional Properties. 
 
-All supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored. 
+Find a list of supported fields for events in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) and  for user properties in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys). Add any columns not in those lists to either `event_properties` or `user_properties`, otherwise it's ignored. 
 
 After you have added all the fields you wish to bring into Amplitude, you can view samples of this configuration in the Data Preview section. Data Preview automatically updates as you include or remove fields and properties. In Data Preview, you can look at a few sample records based on the source records along with how that data is imported into Amplitude. This ensures that you are bringing in all the data points you need into Amplitude. You can look at 10 different sample source records and their corresponding Amplitude events.
 

--- a/docs/data/sources/bigquery.md
+++ b/docs/data/sources/bigquery.md
@@ -98,7 +98,7 @@ Find other supported fields in the [HTTP V2 API documentation](/analytics/apis/h
 | `user_properties` | Yes | JSON | {"city":"chicago", "gender":"female"} |
 | `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
 
-Other supported fields can be found in [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
+Find other supported fields in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
 
 ### Group properties
 

--- a/docs/data/sources/bigquery.md
+++ b/docs/data/sources/bigquery.md
@@ -74,7 +74,7 @@ For Amplitude's time-based import option, it's best practice to use a monotonica
 
 ## Mandatory data fields
 
-You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. You can include other columns beyond those listed here.
+You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored.
 
 ### Events
 
@@ -88,6 +88,8 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_properties` | No | JSON | {"city":"chicago", "gender":"female"} |
 | `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
 
+Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
+
 ### User properties
 
 | Column name (must be lowercase) | Mandatory | Column data type | Example |
@@ -95,6 +97,8 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_id` | Yes | VARCHAR | datamonster@gmail.com |
 | `user_properties` | Yes | JSON | {"city":"chicago", "gender":"female"} |
 | `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
+
+Other supported fields can be found in [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
 
 ### Group properties
 

--- a/docs/data/sources/bigquery.md
+++ b/docs/data/sources/bigquery.md
@@ -88,7 +88,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_properties` | No | JSON | {"city":"chicago", "gender":"female"} |
 | `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
 
-Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
+Find other supported fields in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
 
 ### User properties
 

--- a/docs/data/sources/bigquery.md
+++ b/docs/data/sources/bigquery.md
@@ -74,7 +74,7 @@ For Amplitude's time-based import option, it's best practice to use a monotonica
 
 ## Mandatory data fields
 
-You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored.
+Include the mandatory fields for the data type when you create the SQL query. These tables outline the mandatory and optional fields for each data type. Find a list of other supported fields for events in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) and  for user properties in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys). Add any columns not in those lists to either `event_properties` or `user_properties`, otherwise it's ignored. 
 
 ### Events
 

--- a/docs/data/sources/google-cloud-storage.md
+++ b/docs/data/sources/google-cloud-storage.md
@@ -97,6 +97,8 @@ After you have all the fields needed for the transformation, you can save it. Yo
 
 Although Amplitude needs certain fields to bring data in, it also supports extra fields which you can include by clicking the “Add Mapping” button. Here, Amplitude supports 4 kinds of mappings: Event properties, User Properties, Group Properties and Additional Properties. 
 
+All supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored. 
+
 After you have added all the fields you wish to bring into Amplitude, you can view samples of this configuration in the Data Preview section. Data Preview automatically updates as you include or remove fields and properties. In Data Preview, you can look at a few sample records based on the source records along with how that data is imported into Amplitude. This ensures that you are bringing in all the data points you need into Amplitude. You can look at 10 different sample source records and their corresponding Amplitude events.
 
 ![Screenshot of a converter preview](../../assets/images/converter-preview.png)

--- a/docs/data/sources/google-cloud-storage.md
+++ b/docs/data/sources/google-cloud-storage.md
@@ -97,7 +97,7 @@ After you have all the fields needed for the transformation, you can save it. Yo
 
 Although Amplitude needs certain fields to bring data in, it also supports extra fields which you can include by clicking the “Add Mapping” button. Here, Amplitude supports 4 kinds of mappings: Event properties, User Properties, Group Properties and Additional Properties. 
 
-All supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored. 
+Find a list of supported fields for events in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) and  for user properties in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys). Add any columns not in those lists to either `event_properties` or `user_properties`, otherwise it's ignored.  
 
 After you have added all the fields you wish to bring into Amplitude, you can view samples of this configuration in the Data Preview section. Data Preview automatically updates as you include or remove fields and properties. In Data Preview, you can look at a few sample records based on the source records along with how that data is imported into Amplitude. This ensures that you are bringing in all the data points you need into Amplitude. You can look at 10 different sample source records and their corresponding Amplitude events.
 

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -78,7 +78,7 @@ For Amplitude's time-based import option, it's best practice to use a monotonica
 
 ## Data fields
 
-You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. You can include other columns beyond those listed here.
+You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored.
 
 ### Events
 <!-- vale off-->
@@ -92,6 +92,8 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_properties`               | No                                  | VARIANT (JSON Object)                | {"city":"chicago", "gender":"female"}         |
 | `update_time_column`            | No (Yes if using time based import) | TIMESTAMP_NTZ                        | 2013-04-05 01:02:03.000                       |
 
+Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
+
 ### User properties
 
 | Column name (must be lowercase) | Mandatory                           | Column data type      | Example                               |
@@ -99,6 +101,9 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_id`                       | Yes                                 | VARCHAR               | datamonster@gmail.com                 |
 | `user_properties`               | Yes                                 | VARIANT (JSON Object) | {"city":"chicago", "gender":"female"} |
 | `update_time_column`            | No (Yes if using time based import) | TIMESTAMP_NTZ         | 2013-04-05 01:02:03.000               |
+
+Other supported fields can be found in [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
+
 <!--vale on-->
 ### Group properties
 
@@ -108,7 +113,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `group_properties`              | Yes                                 | VARIANT (JSON Object) | {"location":"seattle", "active":"true"}                |
 | `update_time_column`            | No (Yes if using time based import) | TIMESTAMP_NTZ         | 2013-04-05 01:02:03.000                                |
 
-Each group property in `group_properties` would apply to every group in `groups`
+Each group property in `group_properties` would apply to every group in `groups`.
 
 ### Profile properties
 

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -78,7 +78,7 @@ For Amplitude's time-based import option, it's best practice to use a monotonica
 
 ## Data fields
 
-You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) (events) and [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys) (user properties). Any column not in the list should be added to either `event_properties` or `user_properties`, otherwise it will get ignored.
+Include the mandatory fields for the data type when you create the SQL query. These tables outline the mandatory and optional fields for each data type. Find a list of other supported fields for events in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#keys-for-the-event-argument) and  for user properties in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys). Add any columns not in those lists to either `event_properties` or `user_properties`, otherwise it's ignored. 
 
 ### Events
 <!-- vale off-->

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -92,7 +92,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `user_properties`               | No                                  | VARIANT (JSON Object)                | {"city":"chicago", "gender":"female"}         |
 | `update_time_column`            | No (Yes if using time based import) | TIMESTAMP_NTZ                        | 2013-04-05 01:02:03.000                       |
 
-Other supported fields can be found in [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
+Find other supported fields can in the [HTTP V2 API documentation](/analytics/apis/http-v2-api/#upload-request-headers).
 
 ### User properties
 

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -102,7 +102,7 @@ Other supported fields can be found in [HTTP V2 API documentation](/analytics/ap
 | `user_properties`               | Yes                                 | VARIANT (JSON Object) | {"city":"chicago", "gender":"female"} |
 | `update_time_column`            | No (Yes if using time based import) | TIMESTAMP_NTZ         | 2013-04-05 01:02:03.000               |
 
-Other supported fields can be found in [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
+Find other supported fields in the [Identify API documentation](/analytics/apis/identify-api/#identification-parameter-keys).
 
 <!--vale on-->
 ### Group properties


### PR DESCRIPTION

# Amplitude Developer Docs PR


## Description

Add additional property docs to Snowflake/BigQuery/S3/GCS, which was missing/wrong, hence result in we silently drop additional properties from customer's import.

<img width="1367" alt="Screenshot 2023-11-21 at 3 37 05 PM" src="https://github.com/amplitude/amplitude-dev-center/assets/116029942/8b36cf9f-0aaf-49bc-9d7f-f685602f19ac">


## Deadline

ASAP but not urgent


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
