### PR TITLE
Adding a note regarding auto assignment tracking when using REST API

### DIFF
--- a/docs/experiment/apis/evaluation-api.md
+++ b/docs/experiment/apis/evaluation-api.md
@@ -3,7 +3,7 @@ title: Evaluation REST API
 description: Retrieve variation assignment data for users with the Amplitude Experiment REST API.
 ---
 
-The Amplitude Experiment Evaluation REST API lets you retrieve variant assignment data for users via [remote evaluation](../general/evaluation/remote-evaluation.md). User information passes as query parameters on the request to allow for [caching the response on the CDN](../general/performance-and-caching.md#cdn-caching).
+The Amplitude Experiment Evaluation REST API lets you retrieve variant assignment data for users via [remote evaluation](../general/evaluation/remote-evaluation.md). User information passes as query parameters on the request to allow for [caching the response on the CDN](../general/performance-and-caching.md#cdn-caching). Note that calling this API will automatically trigger an `[Experiment] Assignment` event to be tracked.
 
 !!!tip "[Try it out in your browser!](#example)"
 

--- a/docs/experiment/apis/evaluation-api.md
+++ b/docs/experiment/apis/evaluation-api.md
@@ -3,7 +3,7 @@ title: Evaluation REST API
 description: Retrieve variation assignment data for users with the Amplitude Experiment REST API.
 ---
 
-The Amplitude Experiment Evaluation REST API lets you retrieve variant assignment data for users via [remote evaluation](../general/evaluation/remote-evaluation.md). User information passes as query parameters on the request to allow for [caching the response on the CDN](../general/performance-and-caching.md#cdn-caching). Note that calling this API will automatically trigger an `[Experiment] Assignment` event to be tracked.
+The Amplitude Experiment Evaluation REST API lets you retrieve variant assignment data for users via [remote evaluation](../general/evaluation/remote-evaluation.md). User information passes as query parameters on the request to allow for [caching the response on the CDN](../general/performance-and-caching.md#cdn-caching). When you call this API, Amplitude tracks an `[Experiment] Assignment` event.
 
 !!!tip "[Try it out in your browser!](#example)"
 


### PR DESCRIPTION
Minor improvement to the dev docs to make things that happen underneath the hood a bit more transparent. 

Addressing this Discourse question.
https://discourse.amplitude.com/t/experiments-exposure-events-not-triggering/12144

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
