### PR TITLE
AMP-90189 added security section to iOS SDKs for jailbroken devices

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -993,6 +993,27 @@ Implements a customized `loggerProvider` class from the LoggerProvider, and pass
     Amplitude* amplitude = [Amplitude initWithConfiguration:configuration];
     ```
 
+--8<-- "includes/sdk-ios/sdk-ios-security-set-instance-name.md"
+
+=== "Objective-C"
+
+    ```obj-c
+    AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API-KEY"
+                                                        instanceName:@"my-unqiue-instance-name"];
+    Amplitude* amplitude = [Amplitude instanceWithConfiguration:configuration];
+    ```
+
+=== "Swift"
+
+    ```swift
+    let amplitude = Amplitude(
+        configuration: Configuration(
+            apiKey: "API-KEY",
+            instanceName: "my-unqiue-instance-name"
+        )
+    )
+    ```
+
 ### More resources
 
 If you have any problems or issues with the SDK, [create a GitHub issue](https://github.com/amplitude/Amplitude-Swift/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -1230,6 +1230,20 @@ You can find examples for [Objective-C](https://github.com/amplitude/ampli-exam
 
 Learn more about [Middleware](../../sdk-middleware).
 
+--8<-- "includes/sdk-ios/sdk-ios-security-set-instance-name.md"
+
+=== "Objective-C"
+
+    ```obj-c
+    Amplitude* amplitude = [Amplitude instanceWithName:@"my-unqiue-instance-name"];
+    ```
+
+=== "Swift"
+
+    ```swift
+    var amplitude = Amplitude.instanceWithName("my-unqiue-instance-name")
+    ```
+
 ### More resources
 
 If you have any problems or issues with the SDK, [create a GitHub issue](https://github.com/amplitude/Amplitude-iOS/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/includes/sdk-ios/sdk-ios-security-set-instance-name.md
+++ b/includes/sdk-ios/sdk-ios-security-set-instance-name.md
@@ -1,0 +1,5 @@
+### Security
+
+iOS automatically protects application data by storing each apps data in its own secure directory. This directory is usually not accessible by other applications. However, if a device is jailbroken, apps are granted root access to all directories on the device.
+
+To prevent other apps from accessing your apps Amplitude data on a jailbroken device, we recommend setting a unique instance name for your SDK. This will create a unique database that is isolated from other apps.


### PR DESCRIPTION
## Description

* [AMP-90189](https://amplitude.atlassian.net/browse/AMP-90189)
* added security section to iOS SDKs about setting instanceName to isolate storage on jailbroken devices

## Deadline

**ASAP**

## Change type

- [x] New documentation.
