### PR TITLE
add email as Braze event streaming identifier option

### DIFF
--- a/docs/data/destinations/braze.md
+++ b/docs/data/destinations/braze.md
@@ -45,7 +45,7 @@ _This applies to both event and user forwarding. Transformed user properties are
     - [**External ID**](https://www.braze.com/docs/api/basics/#user-ids): Any unique identifier for each user in Braze.
     - [**Braze ID**](https://www.braze.com/docs/api/basics/#user-ids): A unique identifier provided by Braze for each user.
     - [**User Alias**](https://www.braze.com/docs/api/objects_filters/user_alias_object): An alternative unique identifier for each user in Braze.
-    - [**Email**](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#frequently-asked-questions): Using email as the identifier without an External ID or Braze ID can lead to some unexpected behaviors. Check the [Braze Documentation](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#frequently-asked-questions) for more details.
+    - [**Email**](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#frequently-asked-questions): Using email as the identifier without an External ID or Braze ID may lead to unexpected behavior. 
 
 ### Configure event forwarding
 

--- a/docs/data/destinations/braze.md
+++ b/docs/data/destinations/braze.md
@@ -45,6 +45,7 @@ _This applies to both event and user forwarding. Transformed user properties are
     - [**External ID**](https://www.braze.com/docs/api/basics/#user-ids): Any unique identifier for each user in Braze.
     - [**Braze ID**](https://www.braze.com/docs/api/basics/#user-ids): A unique identifier provided by Braze for each user.
     - [**User Alias**](https://www.braze.com/docs/api/objects_filters/user_alias_object): An alternative unique identifier for each user in Braze.
+    - [**Email**](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#frequently-asked-questions): Using email as the identifier without an External ID or Braze ID can lead to some unexpected behaviors. Check the [Braze Documentation](https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#frequently-asked-questions) for more details.
 
 ### Configure event forwarding
 


### PR DESCRIPTION
# Amplitude Developer Docs PR
Add Email as an identifier option for Braze event streaming and link to Braze documentation FAQ to point out some caveats


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
