### PR TITLE
AMP-90580 Add offline documentation to Android & iOS SDKs

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -1112,6 +1112,22 @@ The Amplitude Android SDK allows the app to set a callback (version 2.32.2+). Cr
     client.setLogCallback(callback);
     ```
 
+--8<-- "includes/sdk-set-offline.md"
+
+=== "Java"
+
+    ```java
+    client.setOffline(true); // enables offline mode
+    client.setOffline(false); // disables offline mode
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+    client.setOffline(true); // enables offline mode
+    client.setOffline(false); // disables offline mode
+    ```
+
 ### Middleware
 
 Middleware lets you extend Amplitude by running a sequence of custom code on every event.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -1210,6 +1210,22 @@ Don't send push notification events client-side via the iOS SDK. Because a user 
 
 You can use [mobile marketing automation partners](https://amplitude.com/integrations?category=mobile-marketing-automation) or the [HTTP API V2](https://developers.amplitude.com/docs/http-api-v2) to send push notification events to Amplitude.
 
+--8<-- "includes/sdk-set-offline.md"
+
+=== "Objective-C"
+
+    ```obj-c
+    [[Amplitude instance] setOffline:YES]; // enables offline mode
+    [[Amplitude instance] setOffline:NO]; // disables offline mode
+    ```
+
+=== "Swift"
+
+    ```swift
+    Amplitude.instance().setOffline(true); // enables offline mode
+    Amplitude.instance().setOffline(false) // disables offline mode
+    ```
+
 ### Middleware
 
 Middleware lets you extend Amplitude by running a sequence of custom code on every event. This pattern is flexible and can be used to support event enrichment, transformation, filtering, routing to third-party destinations, and more.

--- a/includes/sdk-set-offline.md
+++ b/includes/sdk-set-offline.md
@@ -1,0 +1,9 @@
+### Offline Mode
+
+The Amplitude SDK supports offline usage through the `setOffline(isOffline)` method. By default, offline mode is disabled.
+
+When offline mode is enabled, events are saved to a local storage but will not be sent to the Amplitude servers. 
+
+When offline mode is disabled, any pending events are sent to Amplitude's servers immediately. 
+
+To limit the necessary permissions required by the SDK, the SDK does not automatically detect network connectivity. Instead, you must manually call `setOffline()` to enable or disable offline mode.


### PR DESCRIPTION
## Description

From discourse: https://discourse.amplitude.com/t/limits-on-offline-event-capture/12221/19?u=justin

* Add information about setOffline() method to Android & iOS (maintenance) SDK docs
* https://pr-122.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios/#offline-mode
* https://pr-122.d19s7xzcva2mw3.amplifyapp.com/data/sdks/android/#offline-mode

## Change type
- [x] Doc update.

