### PR TITLE
Update mobile SDKs tracking options

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -751,11 +751,13 @@ Tracking for each field can be individually controlled, and has a corresponding 
 | <div class="big-column">Method</div> | Description |
 | --- | --- |
 | `disableAdid()` | Disable tracking of Google ADID |
+| `disableAppSetId()` | Disable tracking of App Set Id |
 | `disableCarrier()` | Disable tracking of device's carrier |
 | `disableCity()` | Disable tracking of user's city |
 | `disableCountry()` | Disable tracking of user's country |
 | `disableDeviceBrand()` | Disable tracking of device brand |
 | `disableDeviceModel()` | Disable tracking of device model |
+| `disableTrackDeviceManufacturer()` | Disable tracking of device manufacturer |
 | `disableDma()` | Disable tracking of user's designated market area (DMA). |
 | `disableIpAddress()` | Disable tracking of user's IP address |
 | `disableLanguage()` | Disable tracking of device's language |
@@ -765,6 +767,7 @@ Tracking for each field can be individually controlled, and has a corresponding 
 | `disablePlatform()` | Disable tracking of device's platform |
 | `disableRegion()` | Disable tracking of user's region. |
 | `disableVersionName()` | Disable tracking of your app's version name |
+| `disableApiLevel` | Disable tracking of Android API level |
 
 !!!note
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -824,21 +824,20 @@ Tracking for each field can be individually controlled, and has a corresponding 
 
 | <div class="big-column">Method</div> | Description |
 | --- | --- |
-| `disableAdid()` | Disable tracking of Google ADID |
-| `disableCarrier()` | Disable tracking of device's carrier |
-| `disableCity()` | Disable tracking of user's city |
-| `disableCountry()` | Disable tracking of user's country |
-| `disableDeviceBrand()` | Disable tracking of device brand |
-| `disableDeviceModel()` | Disable tracking of device model |
-| `disableDma()` | Disable tracking of user's designated market area (DMA). |
-| `disableIpAddress()` | Disable tracking of user's IP address |
-| `disableLanguage()` | Disable tracking of device's language |
-| `disableLatLng()` | Disable tracking of user's current latitude and longitude coordinates |
-| `disableOsName()` | Disable tracking of device's OS Name |
-| `disableOsVersion()` | Disable tracking of device's OS Version |
-| `disablePlatform()` | Disable tracking of device's platform |
-| `disableRegion()` | Disable tracking of user's region. |
-| `disableVersionName()` | Disable tracking of your app's version name |
+| `disableTrackCarrier()` | Disable tracking of device's carrier |
+| `disableTrackCity()` | Disable tracking of user's city |
+| `disableTrackCountry()` | Disable tracking of user's country |
+| `disableTrackDeviceModel()` | Disable tracking of device model|
+| `disableTrackDeviceManufacturer()` | Disable tracking of device manufacturer |
+| `disableTrackDMA()` | Disable tracking of user's designated market area (DMA) |
+| `disableTrackIpAddress()` | Disable tracking of user's IP address |
+| `disableTrackLanguage()` | Disable tracking of device's language |
+| `disableTrackIDFV()` |  | Disable tracking of identifier for vendors (IDFV) |
+| `disableTrackOsName()` | Disable tracking of device's OS Name |
+| `disableTrackOsVersion()` | Disable tracking of device's OS Version |
+| `disableTrackPlatform()` | Disable tracking of device's platform |
+| `disableTrackRegion()` | Disable tracking of user's region |
+| `disableTrackVersionName()` | Disable tracking of your app's version name |
 
 !!!note
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Correct mobile SDKs' tracking options.

Swift SDK has 14 options while Kotlin SDK has 18 in total.
They share 13 same options. 
Swift can disable idfv, while Kotlin can disable `adid`, `appSetId`, `apiLevel`, `latLng`, and `deviceBrand`
Also notice that Swift uses `disableTrackXxxx()` format while Kotlin uses `disableXxxx()`. 

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
