### PR TITLE
Refer to user ID, device ID, and min ID length by camel case for type…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 site/
 .vscode/
 .cache
-
 .idea
+.python-version
+__pycache__/

--- a/docs/data/sdks/browser-2/index.md
+++ b/docs/data/sdks/browser-2/index.md
@@ -29,7 +29,7 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 ### Initialize the SDK
 
---8<-- "includes/sdk-httpv2-notice.md"
+--8<-- "includes/sdk-httpv2-notice-ts.md"
 
 --8<-- "includes/sdk-ts-browser/init.md"
 
@@ -62,7 +62,7 @@ amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com', options);
     |`partnerId` | `string`. Sets partner ID. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. | `undefined` |
     |`sessionTimeout` | `number`. Sets the period of inactivity from the last tracked event before a session expires in milliseconds. | 1,800,000 milliseconds (30 minutes) |
     |`storageProvider`| `Storage<Event[]>`. Sets a custom implementation of `Storage<Event[]>` to persist unsent events. | `LocalStorage` |
-    |`userId` | `number`. Sets an identifier for the user being tracked. Must have a minimum length of 5 characters unless overridden with the `min_id_length` option. | `undefined` |
+    |`userId` | `number`. Sets an identifier for the user being tracked. Must have a minimum length of 5 characters unless overridden with the `minIdLength` option. | `undefined` |
     |`trackingOptions` | `TrackingOptions`. Configures tracking of additional properties. Please refer to `Optional tracking` section for more information. | Enable all tracking options by default. |
     |`transport` | `string`. Sets request API to use by name. Options include `fetch` fro fetch, `xhr` for `XMLHttpRequest`, or  `beacon` for `navigator.sendBeacon`. | `fetch` |
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -35,7 +35,7 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 ### Initialize the SDK
 
---8<-- "includes/sdk-httpv2-notice.md"
+--8<-- "includes/sdk-httpv2-notice-ts.md"
 
 --8<-- "includes/sdk-ts-browser/init.md"
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -94,7 +94,7 @@ amplitude.init(API_KEY, {
 
 ### Tracking an event
 
---8<-- "includes/sdk-httpv2-notice.md"
+--8<-- "includes/sdk-httpv2-notice-ts.md"
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -124,7 +124,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 ### Tracking an event
 
---8<-- "includes/sdk-httpv2-notice.md"
+--8<-- "includes/sdk-httpv2-notice-ts.md"
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 

--- a/docs/data/sources/google-tag-manager-client.md
+++ b/docs/data/sources/google-tag-manager-client.md
@@ -148,7 +148,7 @@ If the user ID is already available you can:
     |`domain`| `string`. Set the top level domain. | `null` |
     |`partnerId`| `string`. The partner Id value. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. | `null` |
     |`sessionTimeout`| `number`. How long one session expire. | `30` minutes. |
-    |`userId`| `number`. ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_id_length` option. | `undefined` |
+    |`userId`| `number`. ID for the user. Must have a minimum length of 5 characters unless overridden with the `minIdLength` option. | `undefined` |
     |`trackingOptions`| `TrackingOptions`. Please check the `Optional tracking` section for more tracking options configuration. | Enable all tracking options by default. |
     |`transport`| `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`. Set the transport type. | `TransportType.Fetch` |
 - `Select a **GTM variable** from the list`. It's necessary to return an object containing the key-value pairs you wish to use for instance configuration. Ensure that the keys are part of the available configurations.

--- a/includes/sdk-httpv2-notice-ts.md
+++ b/includes/sdk-httpv2-notice-ts.md
@@ -1,0 +1,4 @@
+!!!note "Important notes about sending events"
+	This SDK uses the [HTTP V2](https://developers.amplitude.com/docs/http-api-v2) API and follows the same constraints for events. Make sure that all events logged in the SDK have the `event_type` field and at least one of `deviceId`  (included by default) or `userId`, and follow the HTTP API's constraints on each of those fields.
+
+	To prevent instrumentation issues, device IDs and user IDs must be strings with a length of 5 characters or more. If an event contains a device ID or user ID that's too short, the ID value is removed from the event. If the event doesn't have a `userId` or `deviceId` value, the upload may be rejected with a 400 status. Override the default minimum length of 5 characters by setting the `minIdLength` config option.

--- a/includes/sdk-httpv2-notice.md
+++ b/includes/sdk-httpv2-notice.md
@@ -1,4 +1,4 @@
 !!!note "Important notes about sending events"
-	This SDK uses the [HTTP V2](https://developers.amplitude.com/docs/http-api-v2) API and follows the same constraints for events. Make sure that all events logged in the SDK have the `event_type` field and at least one of `device_id` or `user_id`, and follows the HTTP API's constraints on each of those fields. 
+	This SDK uses the [HTTP V2](https://developers.amplitude.com/docs/http-api-v2) API and follows the same constraints for events. Make sure that all events logged in the SDK have the `event_type` field and at least one of `device_id` or `user_id`, and follow the HTTP API's constraints on each of those fields.
 
 	To prevent instrumentation issues, device IDs and user IDs must be strings with a length of 5 characters or more. If an event contains a device ID or user ID that's too short, the ID value is removed from the event. If the event doesn't have a `user_id` or `device_id` value, the upload may be rejected with a 400 status. Override the default minimum length of 5 characters by passing the `min_id_length` option with the request.

--- a/includes/sdk-ts-browser/tracking-an-event.md
+++ b/includes/sdk-ts-browser/tracking-an-event.md
@@ -1,4 +1,4 @@
---8<-- "includes/sdk-httpv2-notice.md"
+--8<-- "includes/sdk-httpv2-notice-ts.md"
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -7,7 +7,7 @@
     |`flushMaxRetries`| `number`. Sets the maximum number of reties for failed upload attempts. This is only applicable to retryable errors. | 5 times.|
     |`logLevel` | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. Sets the log level. | `LogLevel.Warn` |
     |`loggerProvider `| `Logger`. Sets a custom `loggerProvider` class from the Logger to emit log messages to desired destination. | `Amplitude Logger` |
-    |`minIdLength`|  `number`. Sets the minimum length for the value of `user_id` and `device_id` properties. | `5` |
+    |`minIdLength`|  `number`. Sets the minimum length for the value of `userId` and `deviceId` properties. | `5` |
     |`optOut` | `boolean`. Sets permission to track events. Setting a value of `true` prevents Amplitude from tracking and uploading events. | `false` |
     |`serverUrl`| `string`. Sets the URL where events are upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Sets the Amplitude server zone. Set this to `EU` for Amplitude projects created in `EU` data center. | `US` |


### PR DESCRIPTION
…script SDKs to be consistent with config options.

# Amplitude Developer Docs PR


## Description
Was instrumenting the Browser SDK and noticed that we referred to `min_id_length` but the config option is actually `minIdLength`, which is the naming convention we use in client-side TypeScript SDKs. Fixing all of them to reflect that.

## Deadline
N/A

## Change type

- [X] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs