### PR TITLE
Fix the typos in README files

### DIFF
--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -52,7 +52,7 @@ init(API_KEY, {
     |`instanceName`| `string`. The instance name. | `$default_instance` |
     |`flushIntervalMillis`| `number`. Sets the interval of uploading events to Amplitude in milliseconds. | 10,000 (10 seconds) |
     |`flushQueueSize`| `number`. Sets the maximum number of events that are batched in a single upload attempt. | 300 events |
-    |`flushMaxRetries`| `number`. Sets the maximum number of reties for failed upload attempts. This is only applicable to retryable errors. | 12 times.|
+    |`flushMaxRetries`| `number`. Sets the maximum number of retries for failed upload attempts. This is only applicable to retryable errors. | 12 times.|
     |`logLevel` | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. Sets the log level. | `LogLevel.Warn` |
     |`loggerProvider `| `Logger`. Sets a custom `loggerProvider` class from the Logger to emit log messages to desired destination. | `Amplitude Logger` |
     |`minIdLength`|  `number`. Sets the minimum length for the value of `user_id` and `device_id` properties. | `5` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -12,4 +12,4 @@
     |`serverUrl`| `string`. Sets the URL where events are upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Sets the Amplitude server zone. Set this to `EU` for Amplitude projects created in `EU` data center. | `US` |
     |`transportProvider`| `Transport`. Sets a custom implementation of `Transport` to use different request API. | `FetchTransport` |
-    |`useBatch`| `boolean`. Sets whether to upload events to Batch API instead of instead of the default HTTP V2 API or not. | `false` |
+    |`useBatch`| `boolean`. Sets whether to upload events to Batch API instead of the default HTTP V2 API or not. | `false` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -4,7 +4,7 @@
     |`instanceName`| `string`. The instance name. | `$default_instance` |
     |`flushIntervalMillis`| `number`. Sets the interval of uploading events to Amplitude in milliseconds. | 1,000 (1 second) |
     |`flushQueueSize`| `number`. Sets the maximum number of events that are batched in a single upload attempt. | 30 events |
-    |`flushMaxRetries`| `number`. Sets the maximum number of reties for failed upload attempts. This is only applicable to retryable errors. | 5 times.|
+    |`flushMaxRetries`| `number`. Sets the maximum number of retries for failed upload attempts. This is only applicable to retryable errors. | 5 times.|
     |`logLevel` | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. Sets the log level. | `LogLevel.Warn` |
     |`loggerProvider `| `Logger`. Sets a custom `loggerProvider` class from the Logger to emit log messages to desired destination. | `Amplitude Logger` |
     |`minIdLength`|  `number`. Sets the minimum length for the value of `userId` and `deviceId` properties. | `5` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

This PR fixes the typo mistake `reties` with `retries` in couple of README files. It also removes duplicated words `instead of`.

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
