### PR TITLE
Update intercom.md

### DIFF
--- a/docs/data/destinations/intercom.md
+++ b/docs/data/destinations/intercom.md
@@ -60,8 +60,8 @@ _This applies to both event and user forwarding. Transformed user properties are
 
 Under **Send Events**, make sure the toggle is enabled ("Events are sent to Intercom") if you want to stream events to Intercom. When enabled, events are automatically forwarded to Intercom when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration. Events are sent to Intercom as [Intercom data events](https://developers.intercom.com/intercom-api-reference/reference/the-data-event-model). Intercom has a limit of 120 event types.
 
-Note that `[Intercom] event.created` is triggered whenever an event is created within Intercom, including Amplitude’s Event Streaming integration. 
-If you don't want to store these events within Amplitude, you can use our [block or drop filters](https://help.amplitude.com/hc/en-us/articles/16805784778907-Remove-invalid-or-incorrect-data) to remove this data. 
+Intercom triggers an event `[Intercom] event.created` when Intercom creates events, including events from Amplitude's Event Streaming integration.
+If you don't want Amplitude to store these events, use Amplitude's [block or drop filters](https://help.amplitude.com/hc/en-us/articles/16805784778907-Remove-invalid-or-incorrect-data) to remove this data. 
 
 1. In **Select and filter events** choose which events you want to send. Choose only the events you need in Intercom. _Transformed events aren't supported._
 

--- a/docs/data/destinations/intercom.md
+++ b/docs/data/destinations/intercom.md
@@ -60,6 +60,9 @@ _This applies to both event and user forwarding. Transformed user properties are
 
 Under **Send Events**, make sure the toggle is enabled ("Events are sent to Intercom") if you want to stream events to Intercom. When enabled, events are automatically forwarded to Intercom when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration. Events are sent to Intercom as [Intercom data events](https://developers.intercom.com/intercom-api-reference/reference/the-data-event-model). Intercom has a limit of 120 event types.
 
+Note that `[Intercom] event.created` is triggered whenever an event is created within Intercom, including Amplitude’s Event Streaming integration. 
+If you don't want to store these events within Amplitude, you can use our [block or drop filters](https://help.amplitude.com/hc/en-us/articles/16805784778907-Remove-invalid-or-incorrect-data) to remove this data. 
+
 1. In **Select and filter events** choose which events you want to send. Choose only the events you need in Intercom. _Transformed events aren't supported._
 
     !!!warning "Events for anonymous users cannot be streamed"


### PR DESCRIPTION
Customers are confused as to why after enabling Intercom Event Streaming, their data is suddenly flooded with the `[Intercom] event.created` events - this is the default behavior but users can always drop/block this data

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
