### PR TITLE
Update Groups snippet on docs

### DIFF
--- a/docs/data/sdks/go/ampli.md
+++ b/docs/data/sdks/go/ampli.md
@@ -148,40 +148,9 @@ ampli.Instance.Identify(
     },
 )
 ```
+### Groups
 
-### Group Identify
-
---8<-- "includes/editions-growth-enterprise-with-accounts.md"
-
-Call `GroupIdentify()` to identify a group in your app and set/update group properties.
-
-Just as Ampli creates types for events and their properties, it creates types for group properties.
-
-The `GroupIdentify()` function accepts a string `groupType`, a string `groupName`, a Group event instance, and optional `EventOptions`.
-
-For example your tracking plan contains a group `sport:football` has a property called `totalMember`. The property's type is a int.
-
-```Go
-ampli.Instance.GroupIdentify(
-    "sport",
-    "football",
-    ampli.Group.Builder().TotalMember(23).Build(),
-)
-```
-
-### Set group
-
-Call `SetGroup()` to associate a user with their group (for example, their department or company). The `SetGroup()` function accept `userID` `groupType`, `groupName` and optional EventOptions.
-
-```Go
-ampli.Instance.SetGroup("user-id", "sport", []string{"football"})
-```
-
-Multiple group names can be set at once.
-
-```Go
-ampli.Instance.SetGroup("user-id", "sport", []string{"football", "basketball"})
-```
+Groups are not yet supported with the Amplitude Go SDK or Go Ampli Wrapper. If you'd like Groups to be added as a feature, please submit a feature request via the widget in your dashboard or through a ticket at this [link](https://support.amplitude.com).
 
 ### Track
 

--- a/docs/data/sdks/go/ampli.md
+++ b/docs/data/sdks/go/ampli.md
@@ -150,7 +150,7 @@ ampli.Instance.Identify(
 ```
 ### Groups
 
-Groups are not yet supported with the Amplitude Go SDK or Go Ampli Wrapper. If you'd like Groups to be added as a feature, please submit a feature request via the widget in your dashboard or through a ticket at this [link](https://support.amplitude.com).
+The Amplitude Go SDK and Go Ampli Wrapper don't support Groups. If you're interested in this feature, submit a feature request through the widget on the Amplitude dashboard, or through a [support ticket](https://support.amplitude.com).
 
 ### Track
 

--- a/docs/data/sdks/go/ampli.md
+++ b/docs/data/sdks/go/ampli.md
@@ -148,6 +148,7 @@ ampli.Instance.Identify(
     },
 )
 ```
+
 ### Groups
 
 The Amplitude Go SDK and Go Ampli Wrapper don't support Groups. If you're interested in this feature, submit a feature request through the widget on the Amplitude dashboard, or through a [support ticket](https://support.amplitude.com).


### PR DESCRIPTION
feel free to change the language here, but essentially groups don't work on the Go SDK, so the section should be removed and updated with a warning panel instead.

# Amplitude Developer Docs PR


## Description
Confirmed with Engineering that Groups are not supported via Go SDK: https://discourse.amplitude.com/t/unable-to-instrument-groups-using-ampli-go-sdk/12567/4 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
