### PR TITLE
Update mkdocs.yml to remove duplicate Kochava entry from under Other

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -247,7 +247,6 @@ nav:
           - MoEngage: data/sources/moengage.md
         - Other:
           - Datazoom: data/sources/datazoom.md
-          - Kochava: data/sources/kochava.md
           - Blitzllama: data/sources/blitzllama.md
         - Privacy:
           - MetaRouter: data/sources/metarouter.md


### PR DESCRIPTION
Removing the duplicate link for Kochava under Others because it's already under Attribution.

# Amplitude Developer Docs PR


## Description

We have two entries for Kochava in the index tree. One is correctly filed under Attribution while the other one is a duplicate currently filed under Other. This change removes the duplicate and keeps the main link.

## Deadline

N/A


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
