### PR TITLE
AMP-91670 Correct the role requirement in dev doc for S3 and GCS

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -31,8 +31,8 @@ Amazon S3 Import setup has four main phases:
 
 Before you start, make sure you’ve taken care of some prerequisites.
 
-- Make sure you have admin permissions for your Amplitude org.
-- Make sure that a project exists to receive the data. If not, create a new project.
+- Make sure that an Amplitude project exists to receive the data. If not, create a new project.
+- Make sure you are an Admin or Manager of the Amplitude project.
 - Make sure your S3 bucket has data files ready for Amplitude to ingest. They must conform to the mappings that you outline in your converter file.
 
 Before you can ingest data, review your dataset and consider best practices. Make sure your dataset contains the data you want to ingest, and any required fields.

--- a/docs/data/sources/google-cloud-storage.md
+++ b/docs/data/sources/google-cloud-storage.md
@@ -19,9 +19,9 @@ Amplitude's GCS Import feature lets you import event or user properties into you
 
 Before you start, make sure you’ve taken care of some prerequisites.
 
-- Make sure you have admin permissions for your Amplitude org.
 - Make sure you have a GCS service account with the appropriate permissions. [Learn more](#create-a-gcs-service-account-and-set-permissions).
-- Make sure that a project exists to receive the data. If not, create a new project.
+- Make sure that an Amplitude project exists to receive the data. If not, create a new project.
+- Make sure you are an Admin or Manager of the Amplitude project.
 - Make sure your GCS bucket has data files ready for ingestion. They must conform to the mappings that you outline in your converter file.
 - Make sure the data in your GCS bucket follows the format outlined in [Amplitude's HTTP API v2 spec](https://developers.amplitude.com/docs/http-api-v2#keys-for-the-event-argument).
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Thanks to @Rox Chang's testing, the correct requirement is Admin or Manager. This PR is to update dev doc to reflect this.

![image (1)](https://github.com/amplitude/amplitude-dev-center/assets/116029942/7a46568d-8976-447b-9e26-d674ee63735d)


## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes AMP-91670. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
