### PR TITLE
Update index.md to correct the default session expiration time

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -683,7 +683,7 @@ In destination plugin, you are able to overwrite the track(), identify(), groupI
 
 Amplitude groups events together by session. Events that are logged within the same session have the same `session_id`. Sessions are handled automatically so you don't have to manually call `startSession()` or `endSession()`.
 
-You can adjust the time window for which sessions are extended. The default session expiration time is 5 minutes.
+You can adjust the time window for which sessions are extended. The default session expiration time is five minutes.
 
 === "Swift"
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -683,7 +683,7 @@ In destination plugin, you are able to overwrite the track(), identify(), groupI
 
 Amplitude groups events together by session. Events that are logged within the same session have the same `session_id`. Sessions are handled automatically so you don't have to manually call `startSession()` or `endSession()`.
 
-You can adjust the time window for which sessions are extended. The default session expiration time is 30 minutes.
+You can adjust the time window for which sessions are extended. The default session expiration time is 5 minutes.
 
 === "Swift"
 


### PR DESCRIPTION
"You can adjust the time window for which sessions are extended. The default session expiration time is 30 minutes."

updated to

"You can adjust the time window for which sessions are extended. The default session expiration time is 5 minutes."

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
