### PR TITLE
SKY-4308 Add versions endpoint

### DIFF
--- a/docs/experiment/apis/management-api/index.md
+++ b/docs/experiment/apis/management-api/index.md
@@ -13,6 +13,7 @@ The Experiment management API can be used to programmatically create and control
 |[Flag APIs](flags.md)| Flag APIs to create, edit, and display flags, and their properties.  |
 |[Experiment APIs](experiments.md)| Experiment APIs to create, edit, and display experiments, and their properties.  |
 |[Deployment APIs](deployments.md)| Deployment APIs to create, edit, and display deployments that flags or experiments can be assigned to. |
+|[Version APIs](versions.md)| Verion APIs to display a list of versions of flags or experiments that the management api key has access to. |
 
 !!!info "Beta API Migration"
     

--- a/docs/experiment/apis/management-api/versions.md
+++ b/docs/experiment/apis/management-api/versions.md
@@ -28,7 +28,7 @@ Fetch a list of versions of all experiments or flags can the management api key 
 ### Response
 
 A successful request returns a `200 OK` response and a list of versions encoded as JSON in the response body, along with the cursor to next page.
-Versions will be ordered by version creation time descending.
+Versions are ordered by version creation time descending.
 
 !!!example "Example cURL"
     ```bash

--- a/docs/experiment/apis/management-api/versions.md
+++ b/docs/experiment/apis/management-api/versions.md
@@ -2,7 +2,6 @@
 title: Management API Versions Endpoints
 ---
 
-------
 
 ## List versions
 

--- a/docs/experiment/apis/management-api/versions.md
+++ b/docs/experiment/apis/management-api/versions.md
@@ -1,0 +1,168 @@
+---
+title: Management API Versions Endpoints
+---
+
+| <div class="big-column">Name</div> | Description |
+| --- | --- |
+| [List versions](#list-versions) | List versions of all experiments or flags can the management api key has access to. |
+
+------
+
+## List versions
+
+```bash
+GET https://experiment.amplitude.com/api/1/versions
+```
+
+Fetch a list of versions of all experiments or flags can the management api key has access to.
+
+### Query parameters
+
+|Name|Description|
+|---|----|
+|`start`| The ISO 8601 formatted start time of versions to be returned (inclusive).|
+|`end`| The ISO 8601 formatted end time to versions to be returned (exclusive).|
+|`limit`| The max number of deployments to be returned. Capped at 1000.|
+|`cursor`| The offset to start the "page" of results from.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of versions encoded as JSON in the response body, along with the cursor to next page.
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \                                                                                    
+      --url 'https://experiment.amplitude.com/api/1/versions?limit=1000&cursor=3000&start=2023-01-01T00:00:00Z&end=2024-12-31T23:59:59Z' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+???example "Example response (click to open)"
+    ```bash
+        {
+            "nextCursor": 100,
+            "versions": [
+                {
+                    "createdAt": "2023-07-29T03:32:49.594Z",
+                    "createdBy": <userId>,
+                    "version": 3,
+                    "flagConfig": {
+                        "id": <id>,
+                        "projectId": <projectId>,
+                        "deployments": [<deploymentId>],
+                        "key": "flag-key",
+                        "name": "flag-key",
+                        "description": "feature flag access",
+                        "enabled": true,
+                        "evaluationMode": "remote",
+                        "bucketingKey": "amplitude_id",
+                        "bucketingSalt": "mHdQDzeE",
+                        "bucketingUnit": "User",
+                        "variants": [
+                            {
+                                "key": "on"
+                            }
+                        ],
+                        "rolloutPercentage": 0,
+                        "rolloutWeights": {
+                            "on": 1
+                        },
+                        "targetSegments": [
+                            {
+                                "name": "Segment 1",
+                                "conditions": [
+                                    {
+                                        "prop": "country",
+                                        "op": "is",
+                                        "type": "property",
+                                        "values": [
+                                            "United States"
+                                        ]
+                                    }
+                                ],
+                                "percentage": 0,
+                                "bucketingKey": "amplitude_id",
+                                "rolloutWeights": {
+                                    "on": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "createdAt": "2023-07-29T03:32:39.494Z",
+                    "createdBy": <userId>,
+                    "version": 2,
+                    "flagConfig": {
+                        "id": <id>,
+                        "projectId": <projectId>,
+                        "deployments": [<deploymentId>],
+                        "key": "flag-key",
+                        "name": "flag-key",
+                        "description": "feature flag access",
+                        "enabled": false,
+                        "evaluationMode": "remote",
+                        "bucketingKey": "amplitude_id",
+                        "bucketingSalt": "mHdQDzeE",
+                        "bucketingUnit": "User",
+                        "variants": [
+                            {
+                                "key": "on"
+                            }
+                        ],
+                        "rolloutPercentage": 0,
+                        "rolloutWeights": {
+                            "on": 1
+                        },
+                        "targetSegments": [
+                            {
+                                "name": "Segment 1",
+                                "conditions": [
+                                    {
+                                        "prop": "country",
+                                        "op": "is",
+                                        "type": "property",
+                                        "values": [
+                                            "United States"
+                                        ]
+                                    }
+                                ],
+                                "percentage": 0,
+                                "bucketingKey": "amplitude_id",
+                                "rolloutWeights": {
+                                    "on": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "createdAt": "2023-07-29T03:30:45.703Z",
+                    "createdBy": <userId>,
+                    "version": 1,
+                    "flagConfig": {
+                        "id": <id>,
+                        "projectId": <projectId>,
+                        "deployments": [],
+                        "key": "flag-key",
+                        "name": "flag-key",
+                        "description": "",
+                        "enabled": false,
+                        "evaluationMode": "remote",
+                        "bucketingKey": "amplitude_id",
+                        "bucketingSalt": "mHdQDzeE",
+                        "bucketingUnit": "User",
+                        "variants": [
+                            {
+                                "key": "on"
+                            }
+                        ],
+                        "rolloutPercentage": 0,
+                        "rolloutWeights": {
+                            "on": 1
+                        },
+                        "targetSegments": []
+                    }
+                }
+            ]
+        }
+    ```

--- a/docs/experiment/apis/management-api/versions.md
+++ b/docs/experiment/apis/management-api/versions.md
@@ -14,7 +14,7 @@ title: Management API Versions Endpoints
 GET https://experiment.amplitude.com/api/1/versions
 ```
 
-Fetch a list of versions of all experiments or flags can the management api key has access to.
+Fetch a list of versions of all experiments or flags can the management api key has access to, across multiple projects if the key is scoped to them.
 
 ### Query parameters
 
@@ -28,18 +28,19 @@ Fetch a list of versions of all experiments or flags can the management api key 
 ### Response
 
 A successful request returns a `200 OK` response and a list of versions encoded as JSON in the response body, along with the cursor to next page.
+Versions will be ordered by version creation time descending.
 
 !!!example "Example cURL"
     ```bash
     curl --request GET \                                                                                    
-      --url 'https://experiment.amplitude.com/api/1/versions?limit=1000&cursor=3000&start=2023-01-01T00:00:00Z&end=2024-12-31T23:59:59Z' \
+      --url 'https://experiment.amplitude.com/api/1/versions?limit=3&cursor=3000&start=2023-01-01T00:00:00Z&end=2024-12-31T23:59:59Z' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```
 ???example "Example response (click to open)"
     ```bash
         {
-            "nextCursor": 100,
+            "nextCursor": 3003,
             "versions": [
                 {
                     "createdAt": "2023-07-29T03:32:49.594Z",

--- a/docs/experiment/apis/management-api/versions.md
+++ b/docs/experiment/apis/management-api/versions.md
@@ -2,10 +2,6 @@
 title: Management API Versions Endpoints
 ---
 
-| <div class="big-column">Name</div> | Description |
-| --- | --- |
-| [List versions](#list-versions) | List versions of all experiments or flags can the management api key has access to. |
-
 ------
 
 ## List versions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -436,6 +436,7 @@ nav:
           - Flags: experiment/apis/management-api/flags.md
           - Experiments: experiment/apis/management-api/experiments.md
           - Deployments: experiment/apis/management-api/deployments.md
+          - Versions: experiment/apis/management-api/versions.md
   - Session Replay:
       - session-replay/index.md
       - Overview: session-replay/index.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Added an endpoint for getting all versions of all flags and experiments that a management api key has access to, with specified time ranges and pagination options. This endpoint returns both flags and experiments versions. 

## Deadline

When do these changes need to be live on the site?
Ideally, before end of week. 

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [x] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
