### PR TITLE
fix: Update Kotlin offline mode

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -1111,15 +1111,9 @@ val amplitude2 = Amplitude(Configuration(
 
 ### Offline mode
 
-Starting from version 1.13.0, the Amplitude Android Kotlin SDK supports offline mode. The SDK checks network connectivity every time it tracks an event. If the device is connected to network, the SDK schedules a flush. If not, it saves the event to storage. The SDK also listens for changes in network connectivity and flushes all stored events when the device reconnects.
-
-To enable this feature, add the `ACCESS_NETWORK_STATE` permission to `AndroidManifest.xml`. Otherwise, the SDK flushes the event based on `flushIntervalMillis` and `flushQueueSize`.
-
-```xml
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-```
+Starting from version 1.13.0, the Amplitude Android Kotlin SDK supports offline mode. The SDK checks network connectivity every time it tracks an event. If the device is connected to network, the SDK schedules a flush in `flushIntervalMillis`. If not, it saves the event to storage. The SDK also listens for changes in network connectivity and flushes all stored events when the device reconnects.
 
 You can also implement you own offline logic:
 
 1. Set `config.offline` to `AndroidNetworkConnectivityCheckerPlugin.Disabled` to disable the default offline logic.
-2. Toggle `config.offline` by yourself
+2. Toggle `config.offline` by yourself.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

The protection level of [ACCESS_NETWORK_STATE](https://developer.android.com/reference/android/Manifest.permission#ACCESS_NETWORK_STATE) is [normal](https://developer.android.com/guide/topics/permissions/overview#normal) which is granted by the system automatically and cannot be changed on Android 6+

https://developer.android.com/guide/topics/manifest/permission-element.html
<img width="824" alt="image" src="https://github.com/amplitude/amplitude-dev-center/assets/31029607/648df208-f9da-4c6d-a9c1-f4f70b609641">
 
https://source.android.com/docs/core/permissions/runtime_perms#affected-permissions

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
