### PR TITLE
DDI-452 Add note that SR isn't on by default

### DIFF
--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -4,6 +4,12 @@ title: Amplitude Session Replay Overview
 
 This page provides links to documentation that explains how to instrument Session Replay in your web application.
 
+!!!note
+    Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation. For more information, see:
+
+    - The [Plugin](/session-replay/sdks/plugin/) instrumentation instructions, if you use Amplitude's Browser SDK.
+    - The [Standalone](/session-replay/sdks/standalone/) SDK instructions, if you use another third-party analytics tool.
+
 ## SDKs
 
 Amplitude provides a plugin for use with Amplitude's Browser SDK and a standalone SDK for use with third-party analytics providers.

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -2,6 +2,9 @@
 title: Session Replay Browser SDK Plugin
 ---
 
+!!!note "Session Replay Insrumentation"
+    Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation.
+
 This article covers the installation of Session Replay using the Browser SDK plugin. If your site is already instrumented with Amplitude, use this option. If you use a provider other than Amplitude for in-product analytics, choose the [standalone implementation](/session-replay/sdks/standalone).
 
 --8<-- "includes/session-replay/performance.md"

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -1,6 +1,9 @@
 ---
 title: Session Replay Standalone SDK
 ---
+
+!!!note "Session Replay Insrumentation"
+    Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation.
  
 This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add notes to Overview, Plugin, and Standalone that explicitly mention that Session Replay isn't enabled by default, and requires additional setup.

## Deadline

ASAP

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
