### PR TITLE
AMP-90669 [event-streaming] Updated appsflyer docs for s2s key

### DIFF
--- a/docs/data/destinations/appsflyer.md
+++ b/docs/data/destinations/appsflyer.md
@@ -18,7 +18,7 @@ Amplitude CDP's AppsFlyer streaming integration enables you to forward your Ampl
 
 To configure streaming from Amplitude to AppsFlyer, you need the following information from AppsFlyer.
 
-- **AppsFlyer Dev Key**: The AppsFlyer Dev Key used for authentication. See the [AppsFlyer documentation](https://support.appsflyer.com/hc/en-us/articles/211719806-App-settings-#sdk-authentication-dev-key) for help locating your Dev Key.
+- **AppsFlyer S2S Key**: The AppsFlyer S2S Key used for authentication. See the [AppsFlyer documentation](https://support.appsflyer.com/hc/en-us/articles/360004562377-Managing-API-and-Server-to-server-S2S-tokens) for help locating your S2S Key.
 - **AppsFlyer App ID**: The AppsFlyer identifier for your app. It's located in AppsFlyer App Settings and can also be retrieved from the URL in your AppsFlyer Dashboards.
 
 ### Create a new sync
@@ -29,7 +29,7 @@ To configure streaming from Amplitude to AppsFlyer, you need the following infor
 
 ### Enter credentials
 
-1. Select your **AppsFlyer Dev Key**.
+1. Select your **AppsFlyer S2S Key**.
 2. Enter your **AppsFlyer App ID**.
 
 ### Configure event forwarding


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description
Appsflyer is changing the way they allow customers to use the ket for their event streaming integration. In this PR, updated Appsflyer docs for using s2s key instead of dev key. Refer: [Appsflyer docs](https://www.docs.developers.amplitude.com/data/destinations/appsflyer/#configure-event-forwarding)

## Deadline
Can be merged anytime from (02/08/24). Preferably by end of week (02/11/24)

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
