### PR TITLE
Update snowflake-data-share.md

### DIFF
--- a/docs/data/destinations/snowflake-data-share.md
+++ b/docs/data/destinations/snowflake-data-share.md
@@ -15,6 +15,8 @@ Amplitude supports [Snowflake’s Data Share](https://docs.snowflake.com/en/user
 
 Snowflake only supports data share within same region and same cloud. Amplitude's Snowflake is in US West (Oregon) region and using Amazon Web Services. To enable cross region cross cloud data share, reach out to your Account Manager at Amplitude or contact Amplitude Support.
 
+Only one Snowflake Data Share can be set up per project for Events Queries and Merge User Queries.
+
 ## Set up a recurring data export to Snowflake with Data Share
 
 To set up a recurring export of your Amplitude data to Snowflake, follow these steps:

--- a/docs/data/destinations/snowflake-data-share.md
+++ b/docs/data/destinations/snowflake-data-share.md
@@ -15,7 +15,7 @@ Amplitude supports [Snowflake’s Data Share](https://docs.snowflake.com/en/user
 
 Snowflake only supports data share within same region and same cloud. Amplitude's Snowflake is in US West (Oregon) region and using Amazon Web Services. To enable cross region cross cloud data share, reach out to your Account Manager at Amplitude or contact Amplitude Support.
 
-Only one Snowflake Data Share can be set up per project for Events Queries and Merge User Queries.
+Amplitude supports only one Snowflake Data Share per project for events and merge user queries.
 
 ## Set up a recurring data export to Snowflake with Data Share
 


### PR DESCRIPTION
Adding clarification on one Data Share per project limit

# Amplitude Developer Docs PR


## Description

Added "Only one Snowflake Data Share can be set up per project for Events Queries and Merge User Queries."

## Deadline

When Possible


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
