### PR TITLE
AMP-93651 Profile API update throttling limit

### DIFF
--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -41,7 +41,6 @@ The User Profile API serves Amplitude user profiles, which include user properti
 **Throttling errors**
 
 - Amplitude orgs have a limit of 600 all API requests per minute. If you go above this limit, contact Support with the use case and required limit.
-- Amplitude orgs have a limit of 100,000 recommendation requests per minute. If you go above this limit, the API returns the following error response:
     - `{"error":"Number of requests per minute exceeds system limit. Contact Support if you need this limit raised"}`
 - For batch recommendation use cases, consider rate limiting your requests so you don't go above this limit.
 - If you need this limit increased for your org, contact Support.


### PR DESCRIPTION
# Amplitude Developer Docs PR
From customer ticket: https://discourse.amplitude.com/t/user-profile-api-looking-for-suggestions-on-retrieving-recommendation-via-user-profile-api/12559/8

The 100,000 limit on recommendation was old day -- never being hit. 
The 600 limit on all paths were introduced in Jan 2024 (by checking most customer usage) --> it will void 100,000 recommendations given it is more restrict. 

Thus to avoid confusion to customers, just remove old throttling limit on our doc. 

## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
