### PR TITLE
Fix: Browser SDK CSP script loader link

### DIFF
--- a/includes/sdk-ts-browser/shared-csp.md
+++ b/includes/sdk-ts-browser/shared-csp.md
@@ -1,4 +1,4 @@
 If your web app configures the strict Content Security Policy (CSP) for security concerns, adjust the policy to whitelist the Amplitude domains:
 
-* When using ["Script Loader"](../sdk-quickstart/#install-the-dependency), add `https://*.amplitude.com` to `script-src`.
+* When using ["Script Loader"](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-browser#installing-via-script-loader), add `https://*.amplitude.com` to `script-src`.
 * Add `https://*.amplitude.com` to `connect-src`.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Quick start guide links are flaky. Replace the link with the one to github which is more stable.  

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
