### PR TITLE
Update Experiment PHP SDK with AssignmentTrackingProvider docs

### DIFF
--- a/docs/experiment/sdks/javascript-sdk.md
+++ b/docs/experiment/sdks/javascript-sdk.md
@@ -265,7 +265,7 @@ start(user?: ExperimentUser): Promise<void>
 
 | Parameter | Requirement | Description |
 | --- | --- | --- |
-| `user` | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to fetch variants. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. Also sets the user in the SDK for reuse. | `undefined` |
+| `user` | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to fetch variants. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. Also sets the user in the SDK for reuse. |
 
 Call `start()` when your application is initializing, after user information is available to use to evaluate or [fetch](#fetch) variants. The returned promise resolves after loading local evaluation flag configurations and fetching remote evaluation variants.
 

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -286,7 +286,7 @@ You can configure the local evaluation client to send [assignment events](../../
 
 #### AssignmentTrackingProvider
 
-The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. While a default assignment tracking provider is provided for the use of testing, due to its synchronous nature, Amplitude recommends that you use a custom provider for increased flexibility and performance.
+The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. Amplitude provides a default assignment tracking provider, but this is best used for testing due to its synchronous nature. Amplitude recommends that you use a custom provider for increased flexibility and performance.
 
 ```php title="AssignmentTrackingProvider"
 <?php
@@ -303,7 +303,7 @@ interface AssignmentTrackingProvider {
 
 #### DefaultAssignmentTrackingProvider
 
-The default assignment tracking provider is a basic implementation of the interface which uses the internal `Amplitude` package to send assignment events via synchronous HTTP requests.
+The default assignment tracking provider is a basic implementation of the interface which uses the internal `Amplitude` package to send assignment events through synchronous HTTP requests.
 
 ```php title="DefaultAssignmentTrackingProvider"
 <?php

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -295,7 +295,7 @@ interface AssignmentTrackingProvider {
 }
 ```
 
-`track()` is called by the local evaluation client when an assignment event needs to be tracked, which happens when [`evaluate()`](#evaluate) is used. The implementation of `track()` should eventually result in the event being sent to Amplitude Analytics.
+The local evaluation client calls `track()` when it determines there are untracked assignment events. It compares the resulting assignment from `evaluate()` with the assignment cache and tracks it if it's not in the cache.
 
 | Parameter | Requirement | Description |
 | --- | --- | --- |

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -286,7 +286,7 @@ You can configure the local evaluation client to send [assignment events](../../
 
 #### AssignmentTrackingProvider
 
-The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. Amplitude recommends that you use a custom provider for increased flexibility and performance.
+The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. While a default assignment tracking provider is provided for the use of testing, due to its synchronous nature, Amplitude recommends that you use a custom provider for increased flexibility and performance.
 
 ```php title="AssignmentTrackingProvider"
 <?php
@@ -303,7 +303,7 @@ interface AssignmentTrackingProvider {
 
 #### DefaultAssignmentTrackingProvider
 
-The default assignment tracking provider is a basic implementation of the interface which uses the synchronous internal `Amplitude` package. It is only recommended for use of testing and applications where latency is less of a concern.
+The default assignment tracking provider is a basic implementation of the interface which uses the internal `Amplitude` package to send assignment events via synchronous HTTP requests.
 
 ```php title="DefaultAssignmentTrackingProvider"
 <?php

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -274,7 +274,7 @@ if ($variant) {
 
 ### Assignment tracking
 
-The local evaluation client can be [configured](#configuration_1) to automatically send [assignment events](../../general/experiment-event-tracking/#assignment-events) to Amplitude.
+You can configure the local evaluation client to send [assignment events](../../general/experiment-event-tracking/#assignment-events) to Amplitude.
 
 ???config "Configuration Options"
     | <div class="big-column">Name</div> | Description | Default Value |
@@ -286,7 +286,7 @@ The local evaluation client can be [configured](#configuration_1) to automatical
 
 #### AssignmentTrackingProvider
 
-The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. Implementing a custom provider is highly recommended for increased flexibility and performance.
+The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. Amplitude recommends that you use a custom provider for increased flexibility and performance.
 
 ```php title="AssignmentTrackingProvider"
 <?php

--- a/docs/experiment/sdks/php-sdk.md
+++ b/docs/experiment/sdks/php-sdk.md
@@ -186,9 +186,6 @@ initializeLocal(string $apiKey, ?LocalEvaluationConfig $config = null): LocalEva
 You can configure the SDK client on initialization.
 
 ???config "Configuration Options"
-
-    **LocalEvaluationConfig**
-
     | <div class="big-column">Name</div> | Description | Default Value |
     | --- | --- | --- |
     | `serverUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
@@ -197,21 +194,7 @@ You can configure the SDK client on initialization.
     | `httpClient` | The underlying [HTTP client](#custom-http-client) to use for requests, if this is not set, a [default](#guzzlehttpclient) HTTP client will be used. | `null` |
     | `guzzleClientConfig` | The configuration for the underlying default `GuzzleHttpClient` (if used). | [defaults](#guzzlehttpclient) |
     | `bootstrap` | Bootstrap the client with an array of flag key to flag configuration | `[]` |
-    | `assignmentConfig` | Configuration for automatically tracking assignment events after an evaluation. | `null` |
-
-    **AssignmentConfig**
-
-    | <div class="big-column">Name</div> | Description | Default Value |
-    | --- | --- | --- |
-    | `apiKey` | The analytics API key. Not to be confused with the experiment deployment key. | *required* |
-    | `cacheCapacity` | The maximum number of assignments stored in the assignment cache. | `65536` |
-    | `flushQueueSize` | Events wait in the buffer and are sent in a batch. Experiment flushes the buffer when the number of events reaches the `flushQueueSize`. | `200` |
-    | `minIdLength` | The minimum length of `userId` and `deviceId`. | `5` |
-    | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
-    | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `null`, then `serverZone` and `useBatch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
-    | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `false` |
-    | `httpClient` | The underlying [HTTP client](#custom-http-client) to use for requests, if this is not set, a [default](#guzzlehttpclient) HTTP client will be used. | `null` |
-    | `guzzleClientConfig` | The configuration for the underlying default `GuzzleHttpClient` (if used). | [defaults](#guzzlehttpclient) |
+    | [`assignmentConfig`](#assignment-tracking) | Configuration for automatically tracking assignment events after an evaluation. | `null` |
 
 !!!info "EU Data Center"
     If you use Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
@@ -289,6 +272,79 @@ if ($variant) {
 }
 ```
 
+### Assignment tracking
+
+The local evaluation client can be [configured](#configuration_1) to automatically send [assignment events](../../general/experiment-event-tracking/#assignment-events) to Amplitude.
+
+???config "Configuration Options"
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `assignmentTrackingProvider` | The AssignmentTrackingProvider used to send assignment events. | *required* |
+    | `cacheCapacity` | The maximum number of assignments stored in the assignment cache. | `65536` |
+    | `apiKey` | The analytics API key. Not to be confused with the experiment deployment key. | *required* |
+    | `minIdLength` | The minimum length of `userId` and `deviceId`. | `5` |
+
+#### AssignmentTrackingProvider
+
+The local evaluation client uses an assignment tracking provider to send assignment events to Amplitude. Implementing a custom provider is highly recommended for increased flexibility and performance.
+
+```php title="AssignmentTrackingProvider"
+<?php
+interface AssignmentTrackingProvider {
+  public function track(Assignment $assignment): void;
+}
+```
+
+`track()` is called by the local evaluation client when an assignment event needs to be tracked, which happens when [`evaluate()`](#evaluate) is used. The implementation of `track()` should eventually result in the event being sent to Amplitude Analytics.
+
+| Parameter | Requirement | Description |
+| --- | --- | --- |
+| `assignment` | required | The object representing an Experiment assignment event |
+
+#### DefaultAssignmentTrackingProvider
+
+The default assignment tracking provider is a basic implementation of the interface which uses the synchronous internal `Amplitude` package. It is only recommended for use of testing and applications where latency is less of a concern.
+
+```php title="DefaultAssignmentTrackingProvider"
+<?php
+class DefaultAssignmentTrackingProvider implements AssignmentTrackingProvider {
+  public function __construct(Amplitude $amplitude);
+}
+```
+
+???config "Configuration Options"
+
+    **Amplitude**
+
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `apiKey` | The analytics API key. Not to be confused with the experiment deployment key. | *required* |
+    | `config` | Configuration options | `null` |
+
+    **AmplitudeConfig**
+
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `flushQueueSize` | Events wait in the buffer and are sent in a batch. Experiment flushes the buffer when the number of events reaches the `flushQueueSize`. | `200` |
+    | `minIdLength` | The minimum length of `userId` and `deviceId`. | `5` |
+    | `serverZone` | The server zone of the projects. Supports `EU` and `US`. For EU data residency, Change to `EU`. | `US` |
+    | `serverUrl` | The API endpoint URL that events are sent to. Automatically selected by `serverZone` and `useBatch`. If this field is set with a string value instead of `null`, then `serverZone` and `useBatch` are ignored and the string value is used. | `https://api2.amplitude.com/2/httpapi` |
+    | `useBatch` | Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `false` |
+    | `httpClient` | The underlying [HTTP client](#custom-http-client) to use for requests, if this is not set, a [default](#guzzlehttpclient) HTTP client will be used. | `null` |
+    | `guzzleClientConfig` | The configuration for the underlying default `GuzzleHttpClient` (if used). | [defaults](#guzzlehttpclient) |
+    | `logger` | Set to use custom logger. If not set, a [default logger](#custom-logger) is used. | `null` |
+    | `logLevel` | The [log level](#log-level) to use for the logger. | `LogLevel::ERROR` |
+
+```php
+<?php
+$config = \AmplitudeExperiment\Amplitude\AmplitudeConfig::builder()
+          ->useBatch(true)
+          ->minIdLength(10)
+          ->build();
+$amplitude = new \AmplitudeExperiment\Amplitude\Amplitude('<API_Key>', $config);
+$defaultAssignmentTrackingProvider = new \AmplitudeExperiment\Assignment\DefaultAssignmentTrackingProvider($amplitude);
+```
+
 ## Custom Logger
 
 Local and remote evaluation clients can be configured to use a custom logger which implements the PSR logger interface, otherwise a default `error_log`-based logger is used.
@@ -318,7 +374,7 @@ Local and remote evaluation clients can be configured to use a custom HTTP clien
 
 The default Guzzle client can be configured via the `guzzleClientConfig` option in [`RemoteEvaluationConfig`](#configuration) and [`LocalEvaluationConfig`](#configuration_1).
 
-???config "Configuration Options"
+???config "AssignmentConfig Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
         | --- | --- | --- |
     | `timeoutMillis` | The timeout for requests in milliseconds. This timeout applies to the initial request, not subsequent retries. | `10000` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update Experiment PHP SDK with AssignmentTrackingProvider docs

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
