### PR TITLE
DDI-457 Session Replay Updates

### DIFF
--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -50,7 +50,7 @@ const sessionReplayTracking = sessionReplayPlugin();
 amplitude.add(sessionReplayTracking);
 ```
 
-You can also add the code directly to the `<head>` of your site. With his method, be sure that the Browser SDK isn't initialized elsewhere in your application. If you initialize the Browser SDK more than once, you may see mismatches in Device ID or Session ID.
+You can also add the code directly to the `<head>` of your site. With this method, be sure that the Browser SDK isn't initialized elsewhere in your application. If you initialize the Browser SDK more than once, you may see mismatches in Device ID or Session ID.
 
 ```html
 <script src="https://cdn.amplitude.com/libs/analytics-browser-2.1.3-min.js.gz"></script>

--- a/docs/session-replay/sdks/plugin.md
+++ b/docs/session-replay/sdks/plugin.md
@@ -11,7 +11,7 @@ This article covers the installation of Session Replay using the Browser SDK plu
 
 ## Before you begin
 
-Use the latest version of the Session Replay Plugin above version 0.8.1. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
+Use the latest version of the Session Replay Plugin above version 1.0.2. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/plugin-session-replay-browser/CHANGELOG.md) on GitHub.
 
 The Session Replay Plugin requires that:
 
@@ -50,7 +50,7 @@ const sessionReplayTracking = sessionReplayPlugin();
 amplitude.add(sessionReplayTracking);
 ```
 
-You can also add the code directly to the `<head>` of your site.
+You can also add the code directly to the `<head>` of your site. With his method, be sure that the Browser SDK isn't initialized elsewhere in your application. If you initialize the Browser SDK more than once, you may see mismatches in Device ID or Session ID.
 
 ```html
 <script src="https://cdn.amplitude.com/libs/analytics-browser-2.1.3-min.js.gz"></script>
@@ -61,6 +61,9 @@ const sessionReplayTracking = window.sessionReplay.plugin();
 window.amplitude.add(sessionReplayTracking);
 </script>
 ```
+
+!!! tip "Compatability with Google Tag Manager"
+    The Session Replay plugin scripts load asynchronously when you add them to the `<head>` tag of your page. As a result, this implementation isn't compatible with Google Tag Manager. For more information, see [Session Replay Implementation with Google Tag Manager](/session-replay/tag-managers/google-tag-manager).
 
 ## Configuration
 
@@ -168,6 +171,10 @@ When Amplitude captures a replay, it doesn't download and store CSS files or oth
 Session Replay requires that the Browser SDK send Session Start and Session End events, at a minimum. If you instrument events outside of the Browser SDK, Amplitude doesn't tag those events as part of the session replay. This means you can't use tools like Funnel, Segmentation, or Journeys charts to find session replays. You can find session replays with the User Sessions chart or through User Lookup.
 
 If you use a method other than the Browser SDK to instrument your events, consider using the [Session Replay Standalone SDK](/session-replay/sdks/standalone/).
+
+### Replay length and session length don't match
+
+In some scenarios, the length of a replay may exceed the time between the `[Amplitude] Start Session` and `[Amplitude] End Session` events. This happens when a user closes the `[Amplitude] End Session` occurs, but before the Browser SDK and Session Replay plugin can process it. When the user visits that page again, the SDK and plugin process the event and send it to Amplitude, along with the replay. You can verify this scenario occurs if you see a discrepancy between the `End Session Client Event Time` and the `Client Upload Time`.
 
 ### Session replays don't appear in Amplitude 
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -11,13 +11,16 @@ This article covers the installation of Session Replay using the standalone SDK.
 
 ## Before you begin
 
-Use the latest version of the Session Replay standalone SDK above version 0.5.0. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
+Use the latest version of the Session Replay standalone SDK above version 1.0.1. For more information, see the [change log](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/packages/session-replay-browser/CHANGELOG.md) on GitHub.
 
 Session Replay Standalone SDK requires that:
 
 1. Your application is web-based.
 2. You track sessions with a timestamp, which you can pass to the SDK. You inform the SDK whenever a session timestamp changes.
 3. You can provide a device ID to the SDK.
+4. The `Session ID` and `Device ID` you pass to the Standalone SDK must match those sent as event properties to Amplitude.
+
+The Standalone SDK doesn't provide Session management capabilities. Your application or a third-party integration must update the SDK with changes to `Session ID` and `Device ID`. 
 
 --8<-- "includes/session-replay/browsers.md"
 

--- a/docs/session-replay/tag-managers/google-tag-manager.md
+++ b/docs/session-replay/tag-managers/google-tag-manager.md
@@ -1,0 +1,52 @@
+---
+title: Session Replay Implementation with Google Tag Manager
+---
+
+Instrumenting Amplitude Session Replay with Google Tag Manager requires a different procedure than with the standard [Browser SDK Plugin](/session-replay/sdks/plugin). To instrument Session Replay with Google Tag Manager:
+
+1. Add the [Google Tag Manager Web Template for Amplitude Analytics Browser SDK](/data/sources/google-tag-manager-client/) if it's not yet enabled.
+2. In Google Tag Manager, create an **init** tag with the same API key as your Amplitude Project. This is the project that receives the session replays.
+   1. Set the **Trigger** to `Initialization - All Pages`.
+   2. Amplitude recommends that you enable default event tracking for better search support with Session Replay. Default events count against your event quota.
+3. Create a **Custom HTML** tag for Session Replay, and paste the code shown below.
+4. Set **Trigger** for the Session Replay Tag to `Initialization - All Pages`.
+5. Deploy the tags. Replays should begin to appear on the home page of the Amplitude app. Ensure that you're looking at the correct project.
+
+
+```html title="Session Replay Script for Google Tag Manager" hl_lines="22"
+<script>
+    function loadAsync(src, callback) {
+      var script = document.createElement('script');
+      script.src = src;
+      if (script.readyState) { // IE, incl. IE9
+        script.onreadystatechange = function() {
+            if (script.readyState === "loaded" || script.readyState === "complete") {
+                script.onreadystatechange = null;
+                callback();
+            }
+        };
+      } else {
+        script.onload = function() { // Other browsers
+            callback();
+        };
+      }
+      document.getElementsByTagName('head')[0].appendChild(script);
+    }
+
+    loadAsync("https://cdn.amplitude.com/libs/plugin-session-replay-browser-0.8.1-min.js.gz", 
+      function () {
+        window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1})); 
+    });
+
+</script>
+```
+
+!!! info "Sample Rate"
+    The sample rate in this sample is set to 1, or 100%, which means every session is captured. This is good for testing, but not recommended for production. For more information, see [Session Replay Plugin | Sample Rate](/session-replay/sdks/plugin/#sampling-rate).
+
+## Troubleshooting
+
+Multiple instantiation of the Amplitude SDKs. This is a common problem seen with GTM and other code injection frameworks. Ensure that the initialization logic is only run once on your app. This could happen if:
+
+- There is more than 1 “Init Tag” or another custom tag that’s running Amplitude. 
+- You have another Code Injection Framework (for example, SquareSpace or Bubble) that also runs Amplitude. 

--- a/docs/session-replay/tag-managers/google-tag-manager.md
+++ b/docs/session-replay/tag-managers/google-tag-manager.md
@@ -32,7 +32,7 @@ Instrumenting Amplitude Session Replay with Google Tag Manager requires a differ
       document.getElementsByTagName('head')[0].appendChild(script);
     }
 
-    loadAsync("https://cdn.amplitude.com/libs/plugin-session-replay-browser-0.8.1-min.js.gz", 
+    loadAsync("https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.0.2-min.js.gz", 
       function () {
         window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1})); 
     });

--- a/docs/session-replay/tag-managers/google-tag-manager.md
+++ b/docs/session-replay/tag-managers/google-tag-manager.md
@@ -12,7 +12,6 @@ Instrumenting Amplitude Session Replay with Google Tag Manager requires a differ
 4. Set **Trigger** for the Session Replay Tag to `Initialization - All Pages`.
 5. Deploy the tags. Replays should begin to appear on the home page of the Amplitude app. Ensure that you're looking at the correct project.
 
-
 ```html title="Session Replay Script for Google Tag Manager" hl_lines="22"
 <script>
     function loadAsync(src, callback) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -443,6 +443,8 @@ nav:
       - SDKs:
         - Browser SDK Plugin: session-replay/sdks/plugin.md
         - Standalone SDK: session-replay/sdks/standalone.md
+      - Tag Managers:
+        - Google Tag Manager: session-replay/tag-managers/google-tag-manager.md
       - Ingestion Monitor: session-replay/ingestion-monitor.md
 
 - Guides:


### PR DESCRIPTION
## Plugin Doc

- [x]  Updated to version 1.0.2
- [x] Added note to point to GTM implementation, and to look out for more than one initialization
- [x] Add FAQ / troubleshooting item around session definition.

## Standalone Doc

- [x] update latest version version to 1.0.2.
- [x] Added note that Standalone SDK does not come with Session management capabilities
- [x] Add a 4th bullet point, the the device id and session id passed to the  standalone SDK needs to match the same properties on the events sent to Amplitude. 

## GTM Implementation

- [x] Created article and listed it under a new Tag Managers category   