### PR TITLE
Update curl exmple

### DIFF
--- a/docs/analytics/domain-proxy.md
+++ b/docs/analytics/domain-proxy.md
@@ -89,7 +89,7 @@ After you create the configuration file, you can start and test your proxy. Usin
 Here is an example curl command that would test your reverse proxy:
 
 ```curl
-curl --data 'api_key=API_Key' --data-urlencode 'event=[{"user_id":"12345", "event_type":"test_proxy_event", "time":1396381378123}]' http://localhost:8080/amplitude/
+curl -X POST http://localhost:8888/amplitude -H "Content-Type: application/json" --data '{"api_key":"API_Key","events":[{"user_id":"12345", "event_type":"test_proxy_event", "time":1396381378123}]}
 ```
 
 This call should return a `200` response code. In the web app, confirm that Amplitude received the event using User Lookup.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

While configuring a Domain Proxy to relay events, I found that the provided cURL example does not work as intended. The issue lies with the use of the `--data-urlencode` option, which is designed for encoding query string parameters rather than sending JSON data in the request body. This results in the JSON being encoded in a manner that the server may not interpret as valid JSON.

## Deadline

When do these changes need to be live on the site?
ASAP

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
