### PR TITLE
DDI-462 Broaden use case for Standalone SDK

### DIFF
--- a/docs/session-replay/index.md
+++ b/docs/session-replay/index.md
@@ -8,7 +8,7 @@ This page provides links to documentation that explains how to instrument Sessio
     Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation. For more information, see:
 
     - The [Plugin](/session-replay/sdks/plugin/) instrumentation instructions, if you use Amplitude's Browser SDK.
-    - The [Standalone](/session-replay/sdks/standalone/) SDK instructions, if you use another third-party analytics tool.
+    - The [Standalone](/session-replay/sdks/standalone/) SDK instructions, if you instrument Amplitude through any other method.
 
 ## SDKs
 

--- a/docs/session-replay/sdks/standalone.md
+++ b/docs/session-replay/sdks/standalone.md
@@ -5,7 +5,7 @@ title: Session Replay Standalone SDK
 !!!note "Session Replay Insrumentation"
     Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation.
  
-This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
+This article covers the installation of Session Replay using the standalone SDK. If you use a provider other than Amplitude for in-product analytics, choose this option. If your site is already instrumented with Amplitude Browser SDK, use the [Session Replay Browser SDK Plugin](/session-replay/sdks/plugin).
 
 --8<-- "includes/session-replay/performance.md"
 


### PR DESCRIPTION
DDI-462: Customers can become confused about when to use the standalone SDK. Broadened the messaging around when to use the Standalone.
