### PR TITLE
Revert "Update Kotlin offline mode (#168)"

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -1111,9 +1111,15 @@ val amplitude2 = Amplitude(Configuration(
 
 ### Offline mode
 
-Starting from version 1.13.0, the Amplitude Android Kotlin SDK supports offline mode. The SDK checks network connectivity every time it tracks an event. If the device is connected to network, the SDK schedules a flush in `flushIntervalMillis`. If not, it saves the event to storage. The SDK also listens for changes in network connectivity and flushes all stored events when the device reconnects.
+Starting from version 1.13.0, the Amplitude Android Kotlin SDK supports offline mode. The SDK checks network connectivity every time it tracks an event. If the device is connected to network, the SDK schedules a flush. If not, it saves the event to storage. The SDK also listens for changes in network connectivity and flushes all stored events when the device reconnects.
+
+To enable this feature, add the `ACCESS_NETWORK_STATE` permission to `AndroidManifest.xml`. Otherwise, the SDK flushes the event based on `flushIntervalMillis` and `flushQueueSize`.
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
 
 You can also implement you own offline logic:
 
 1. Set `config.offline` to `AndroidNetworkConnectivityCheckerPlugin.Disabled` to disable the default offline logic.
-2. Toggle `config.offline` by yourself.
+2. Toggle `config.offline` by yourself


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

This reverts https://github.com/amplitude/amplitude-dev-center/pull/168 commit b388be9aa3802b8fa7b3f94e1559f3de7eb28fab.

It has been reported internally that an error occurs if `ACCESS_NETWORK_STATE` is not added to the manifest file [here](https://amplitude.atlassian.net/browse/AMP-94468), even though
- It should be granted automatically
- SDK checks permission before using it [here](https://github.com/amplitude/Amplitude-Kotlin/blob/669eead95c7cd745f63481663fad5ea473feb99d/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkConnectivityChecker.kt#L20-L36)

This is workaround for now. Will take a closer look later.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
