### PR TITLE
Add support for globals

### DIFF
--- a/docs/session-replay/sdks/plugin-android.md
+++ b/docs/session-replay/sdks/plugin-android.md
@@ -4,6 +4,8 @@ title: Session Replay Android SDK Plugin (ALPHA)
 
 --8<-- "includes/session-replay/eap-warning-android.md"
 
+{*android.session_replay.plugin.version*}
+
 !!!note "Session Replay Instrumentation"
     Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation.
 

--- a/docs/session-replay/sdks/plugin-android.md
+++ b/docs/session-replay/sdks/plugin-android.md
@@ -4,8 +4,6 @@ title: Session Replay Android SDK Plugin (ALPHA)
 
 --8<-- "includes/session-replay/eap-warning-android.md"
 
-{*android.session_replay.plugin.version*}
-
 !!!note "Session Replay Instrumentation"
     Session Replay isn't enabled by default, and requires setup beyond the standard Amplitude instrumentation.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ plugins:
       j2_variable_end_string: '}}'
   - markdownextradata:
       jinja_options:
-        variable_start_string: '{$'
+        variable_start_string: '@{$'
         variable_end_string: '$}'     
 
 # Extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,10 @@ plugins:
       j2_block_end_string: '%}'
       j2_variable_start_string: '@{{'
       j2_variable_end_string: '}}'
+  - markdownextradata:
+      jinja_options:
+        variable_start_string: '{*'
+        variable_end_string: '*}'     
 
 # Extensions
 # When you add or change an extension here, mirror changes in insiders.mkdocs.yml.
@@ -152,9 +156,11 @@ extra:
       as to measure the effectiveness of our documentation and whether users
       find what they're searching for. With your consent, you're helping us to
       make our documentation better. For more information, see Amplitude's <a href="https://amplitude.com/privacy" target="_blank">Privacy Policy</a>.
-
   generator: false #hides the generated with text in the footer
-
+  android:
+    session_replay:
+      plugin:
+        version: 0.5+
 # Navigation
 nav:
 - Documentation:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,8 +75,8 @@ plugins:
       j2_variable_end_string: '}}'
   - markdownextradata:
       jinja_options:
-        variable_start_string: '{*'
-        variable_end_string: '*}'     
+        variable_start_string: '{$'
+        variable_end_string: '$}'     
 
 # Extensions
 # When you add or change an extension here, mirror changes in insiders.mkdocs.yml.


### PR DESCRIPTION
Added support for global variables with [mkdocs-markdownextradata-plugin](https://github.com/rosscdh/mkdocs-markdownextradata-plugin).

Store variables in the `extra:` array in `mkdocs.yml` and wrap them in `@{$ ... $}` to reference them in content.

For example:

```
android:
  session_replay:
    plugin:
      version: 0.5+
```

resolves to `@{$ android.session_replay.plugin.version $}`
