### PR TITLE
fix: remove transportProvider from Browser 2.x

### DIFF
--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -11,5 +11,4 @@
     |`optOut` | `boolean`. Sets permission to track events. Setting a value of `true` prevents Amplitude from tracking and uploading events. | `false` |
     |`serverUrl`| `string`. Sets the URL where events are upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Sets the Amplitude server zone. Set this to `EU` for Amplitude projects created in `EU` data center. | `US` |
-    |`transportProvider`| `Transport`. Sets a custom implementation of `Transport` to use different request API. | `FetchTransport` |
     |`useBatch`| `boolean`. Sets whether to upload events to Batch API instead of the default HTTP V2 API or not. | `false` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Remove `config.transportProvider` from Browser 2.x
 - It's hidden in Browser 2.x https://github.com/amplitude/Amplitude-TypeScript/blob/790311c1286237c9e081789789b2693a5d67160e/packages/analytics-types/src/config/browser.ts#L60C1-L63C95. 
 - It's configurable in Browser 1.x https://github.com/amplitude/Amplitude-TypeScript/blob/1d08e7d07c782a722837857b81e49f00c643f697/packages/analytics-types/src/config/browser.ts#L55C1-L57C2

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes [#[insert issue number]](https://amplitude.atlassian.net/browse/AMP-93005). Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
