### PR TITLE
fix: improved flush() docs in to standalone Android session replay

### DIFF
--- a/docs/session-replay/sdks/plugin-android.md
+++ b/docs/session-replay/sdks/plugin-android.md
@@ -238,4 +238,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.
 - Replays older than the set [retention period](#retention-period) (defaults to 90 days).
 
-*[alpha]: This product is in alpha.
+*[alpha]: This product is in active development. Improvements will be made to this feature.

--- a/docs/session-replay/sdks/standalone-android.md
+++ b/docs/session-replay/sdks/standalone-android.md
@@ -41,6 +41,7 @@ Configure your application code.
 1. Create a  `val sessionReplay = SessionReplay()` object to begin collecting replays. Pass the API key, session identifier, and device identifier.
 2. When the session identifier changes, pass the new value to Amplitude with `sessionReplay.setSessionId`.
 3. Collect Session Replay properties to send with other event properties with `sessionReplay.getSessionReplayProperties`
+4. Send the session replay data to Amplitude by calling `sessionReplay.flush`. Always call flush before the app is exited or sent to the background. For longer sessions, flush should be called periodically to prevent high memory usage (alpha).
 
 ```kotlin
 import com.amplitude.android.sessionreplay.SessionReplay
@@ -70,9 +71,8 @@ ThirdPartyAnalytics.setSessionId(sessionId)
 // Update the session ID in session replay
 sessionReplay.setSessionId(ThirdPartyAnalytics.getSessionId())
 
-// Call `flush()` to send session recordings to the server
+// Send session replay data to the server
 // This should always be called before app exit
-// For longer sessions, flush should be called periodically to prevent high memory usage (alpha)
 sessionReplay.flush()
 ```
 

--- a/docs/session-replay/sdks/standalone-android.md
+++ b/docs/session-replay/sdks/standalone-android.md
@@ -209,4 +209,4 @@ In general, replays should be available within minutes of ingestion. Delays or e
 - Page instrumentation. If Session Replay isn't implemented on all pages a user visits, their session may not capture properly.
 - Replays older than the set [retention period](#retention-period) (defaults to 90 days).
 
-*[alpha]: This product is in active development.
+*[alpha]: This product is in active development. Improvements will be made to this feature.

--- a/docs/session-replay/sdks/standalone-android.md
+++ b/docs/session-replay/sdks/standalone-android.md
@@ -41,7 +41,7 @@ Configure your application code.
 1. Create a  `val sessionReplay = SessionReplay()` object to begin collecting replays. Pass the API key, session identifier, and device identifier.
 2. When the session identifier changes, pass the new value to Amplitude with `sessionReplay.setSessionId`.
 3. Collect Session Replay properties to send with other event properties with `sessionReplay.getSessionReplayProperties`
-4. Send the session replay data to Amplitude by calling `sessionReplay.flush`. Always call flush before the app is exited or sent to the background. For longer sessions, flush should be called periodically to prevent high memory usage (alpha).
+4. Call `sessionReplay.flush` to send session replay data to Amplitude. Always call `flush` before exiting the app or sending it to the background. For longer sessions, call flush frequently to prevent high memory use (alpha).
 
 ```kotlin
 import com.amplitude.android.sessionreplay.SessionReplay


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

*  improved flush() docs in to standalone Android session replay

## Change type

- [x] Doc update.

@amplitude-dev-docs
