### PR TITLE
AMP-96376 - Add breaking changes warning in the migration guide to bring attention

### DIFF
--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -7,6 +7,13 @@ Amplitude Browser SDK 1.0 (`@amplitude/analytics-browser`) features a plugin arc
 
 To migrate to `@amplitude/analytics-browser`, update your dependencies and instrumentation.
 
+!!! warning "Breaking change"
+
+    Migrate to @amplitude/analytics-browser result in significant changes that could potentially cause disruptions. We recommend checking the SDK documentation and the [comparison section](./#comparison) for detailed information.
+
+    Web Attribution:
+    -  SDK tracks attributions with a new campaign on a new session or during a session, and it's not configurable. 
+
 !!!info "Browser SDK 2.0 is now available"
     An improved version of Amplitude Browser SDK is now available. Amplitude Browser SDK 2.0 features default event tracking, improved marketing attribution tracking, simplified interface and a lighter weight package. Amplitude recommends the Browser SDK 2.0 for both product analytics and marketing analytics use cases. Upgrade to the latest [Browser SDK 2.0](../browser-2/index.md). See the [Migration Guide](../browser-2/migration.md) for more help.
 

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -7,15 +7,15 @@ Amplitude Browser SDK 1.0 (`@amplitude/analytics-browser`) features a plugin arc
 
 To migrate to `@amplitude/analytics-browser`, update your dependencies and instrumentation.
 
-!!! warning "Breaking change"
+!!!info "Browser SDK 2.0 is now available"
+    An improved version of Amplitude Browser SDK is now available. Amplitude Browser SDK 2.0 features default event tracking, improved marketing attribution tracking, simplified interface and a lighter weight package. Amplitude recommends the Browser SDK 2.0 for both product analytics and marketing analytics use cases. Upgrade to the latest [Browser SDK 2.0](../browser-2/index.md). See the [Migration Guide](../browser-2/migration.md) for more help.
+
+!!! warning "Breaking changes"
 
     Migrate to @amplitude/analytics-browser result in significant changes that could potentially cause disruptions. We recommend checking the SDK documentation and the [comparison section](./#comparison) for detailed information.
 
     Web Attribution:
     -  SDK tracks attributions with a new campaign on a new session or during a session, and it's not configurable. 
-
-!!!info "Browser SDK 2.0 is now available"
-    An improved version of Amplitude Browser SDK is now available. Amplitude Browser SDK 2.0 features default event tracking, improved marketing attribution tracking, simplified interface and a lighter weight package. Amplitude recommends the Browser SDK 2.0 for both product analytics and marketing analytics use cases. Upgrade to the latest [Browser SDK 2.0](../browser-2/index.md). See the [Migration Guide](../browser-2/migration.md) for more help.
 
 ### Terminology
 

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -12,10 +12,9 @@ To migrate to `@amplitude/analytics-browser`, update your dependencies and instr
 
 !!! warning "Breaking changes"
 
-    Migrate to @amplitude/analytics-browser result in significant changes that could potentially cause disruptions. We recommend checking the SDK documentation and the [comparison section](./#comparison) for detailed information.
+    Migration to `@amplitude/analytics-browser` may result in changes that can cause disruption to Web Attribution your implementation. Before you upgrade, you can choose if attribution occurs during a session, or not. After you upgrade, attribution can happen during the session, and is no longer configurable.
 
-    Web Attribution:
-    -  SDK tracks attributions with a new campaign on a new session or during a session, and it's not configurable. 
+    In both versions, attribution can happen during initialization.
 
 ### Terminology
 

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -12,7 +12,7 @@ To migrate to `@amplitude/analytics-browser`, update your dependencies and instr
 
 !!! warning "Breaking changes"
 
-    Migration to `@amplitude/analytics-browser` may result in changes that can cause disruption to Web Attribution your implementation. Before you upgrade, you can choose if attribution occurs during a session, or not. After you upgrade, attribution can happen during the session, and is no longer configurable.
+    Migration to `@amplitude/analytics-browser` may result in changes that can cause disruption to Web Attribution in your implementation. Before you upgrade, you can choose if attribution occurs during a session, or not. After you upgrade, attribution can happen during the session, and is no longer configurable.
 
     In both versions, attribution can happen during initialization.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Migrating to the Amplitude SDK 2.0 will cause the breaking of changes. We have a lot of customers didn't aware of the changes, especially for the web attribution part. Even if we have a behavior comparison at the end of this doc, we want to bring more attention. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
