### PR TITLE
AMP-90198 add max number of recommend items Profile API can return

### DIFF
--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -152,7 +152,7 @@ Retrieve a single recommendation by ID.
 
     This feature is available in accounts with Amplitude Audiences.
 
-    There is a max number of recommended items that can be returned by API, default value is 50 and max value is 100. This can be changed on Amplitude Recommendation page.
+Amplitude recommends returning 50 items per request. The maximum allowable is 100 items. Update this value on the Amplitude Recommendation page.
 
 Retrieves multiple recommendations for a user.
 

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -68,6 +68,8 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
     This feature is available in accounts with Amplitude Audiences.
 
+    There is a max number of recommended items that can be returned by API, default value is 50 and max value is 100. This can be changed on Amplitude Recommendation page.
+
 Retrieve a single recommendation by ID.
 
 ### Request
@@ -149,6 +151,8 @@ Retrieve a single recommendation by ID.
 !!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
+
+    There is a max number of recommended items that can be returned by API, default value is 50 and max value is 100. This can be changed on Amplitude Recommendation page.
 
 Retrieves multiple recommendations for a user.
 

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -68,7 +68,7 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
     This feature is available in accounts with Amplitude Audiences.
 
-    There is a max number of recommended items that can be returned by API, default value is 50 and max value is 100. This can be changed on Amplitude Recommendation page.
+Amplitude recommends returning 50 items per request. The maximum allowable is 100 items. Update this value on the Amplitude Recommendation page.
 
 Retrieve a single recommendation by ID.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

See this request: https://amplitude.atlassian.net/browse/AMP-90198

customers/CSM wants the limit to be documented in dev doc, thus add the note section. 

## Deadline

When do these changes need to be live on the site?

No hard deadline

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
