### PR TITLE
AMP-91621 update Profile API dev doc on multiple computation IDs support

### DIFF
--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -416,15 +416,18 @@ Retrieve all computations for a user.
 
 ```
 
-## Get a single computation
+## Get single/multiple computation
 
 !!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
-Retrieves a single computation by ID. Find the computation ID by navigating to the computation in the Audiences web app and copying the ID at the end of the URL. The ID is bold in this example:
+Retrieves a single or multiple computation by ID(s). Find the computation ID by navigating to the computation in the Audiences web app and copying the ID at the end of the URL. The ID is bold in this example: https://app.amplitude.com/audiences/org_name_00000/computations/**t14bqib**/
 
-<recommend.amplitude.com/org/00000/computations/**t14bqib**>
+!!!note "Multiple Computation"
+
+    To fetch multiple comp_id, separate comp_id by comma(,). For example: `comp_id=id1,id2`. Responses for multiple comp_id IDs are in the `amp_props` field.
+
 
 ### Request
 

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -422,7 +422,7 @@ Retrieve all computations for a user.
 
     This feature is available in accounts with Amplitude Audiences.
 
-Retrieves a single or multiple computation by ID(s). Find the computation ID by navigating to the computation in the Audiences web app and copying the ID at the end of the URL. The ID is bold in this example: https://app.amplitude.com/audiences/org_name_00000/computations/**t14bqib**/
+Retrieves a single or multiple computation by ID. Navigate to the computation in Audiences to find and copy the ID at the end of the URL. For example, `t14bqib` is the ID in  `https://app.amplitude.com/audiences/org_name_00000/computations/t14bqib/`
 
 !!!note "Multiple Computation"
 

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -428,7 +428,6 @@ Retrieves a single or multiple computation by ID. Navigate to the computation in
 
     To fetch multiple comp_id, separate comp_id by comma(,). For example: `comp_id=id1,id2`. Responses for multiple comp_id IDs are in the `amp_props` field.
 
-
 ### Request
 
 Retrieve a computation for a user by ID.

--- a/docs/data/destinations/webhooks-streaming.md
+++ b/docs/data/destinations/webhooks-streaming.md
@@ -8,36 +8,31 @@ Amplitude's Webhook integration enables you to forward your Amplitude events and
 ## Use cases
 
 1. **Workflow Automation:** Webhooks are key in automating workflows and connecting disparate systems. They automatically trigger actions based on specified events or conditions. This helps streamline processes, reduce manual interventions, and boost operational efficiency. For example, create a webhook to automate the capture and recording of user consent. When a user accepts the terms of service, the webhook triggers and Amplitude logs the event, streamlining consent management and ensuring compliance and data accuracy.
-
 2. **Additional Flexibility Beyond Standard Streaming Integrations:** Webhooks provide enhanced customization and flexibility beyond standard streaming integrations, enabling real-time data exchange and tailored interactions for dynamic and responsive systems. For example, use a webhook to send specific event data from Amplitude to Braze, a use case the native Amplitude Braze streaming integration doesn't support. This involves transforming an Amplitude user property named `newsletters`, an array with `market` and `newsletter_names`, into a format suitable for Braze. Webhooks also enable you to format event data for Braze, to ensure correct processing as purchase events.
 
-## Prerequisites
+## Setup
+
+### Prerequisites
 
 To configure streaming from Amplitude to your webhook, you need the following information.
 
 - **Webhook URL** The destination URL Amplitude should use to send events and users.
 - **Header Information** You can set up to five extra headers for the webhook request.
 
-## Authentication
-
-Webhook Event Streaming supports [Http Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). To authenticate your calls:
-
-Add an `Authorization` header with the value: `Basic <hash>` where `<hash>` is the Base64 encoded result 
-
-## Create a new sync
+### Create a new sync
 
 1. In Amplitude Data, click **Catalog** and select the **Destinations** tab.
 2. In the Event Streaming section, click **Webhook**.
 3. Enter a sync name, then click **Create Sync**.
 
-## Enter webhook URL
+### Enter webhook URL
 
 Enter the URL endpoint for the webhook. For example, `https://mycompany.com/webhook`.
 Note that Amplitude doesn't have a single IP address for forwarding events and users, so ensure that your URL can receive payloads from any Amplitude hosts.
 
 See details on [Amplitude's retry mechanism](#amplitudes-retry-mechanism) in case a webhook call fails.
 
-## Select headers
+### Select headers
 
 There are two preset headers for every webhook sync:
 
@@ -50,13 +45,7 @@ After these preset headers, you can define five more headers. To create a new he
 2. Enter the header value on the right side text box
 3. A new header row appears if limit isn't reached
 
-### Authentication
-
-Webhook Event Streaming supports [Http Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). To authenticate your calls:
-
-Add an `Authorization` header with the value: `Basic <hash>` where `<hash>` is the Base64 encoded result of the `username:password` values of the system the webhook connects to.
-
-## Configure event forwarding
+### Configure event forwarding
 
 Under **Send Events**, make sure the toggle is enabled ("Events are sent to Webhook") if you want to stream events to the webhook. When enabled, events are automatically forwarded to the webhook when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration.
 
@@ -66,7 +55,7 @@ Under **Send Events**, make sure the toggle is enabled ("Events are sent to Webh
 
 2. In **Select and filter events** choose which events you want to send. Choose only the events you need in the webhook. _Transformed events aren't supported._
 
-## Configure user forwarding
+### Configure user forwarding
 
 Under **Send Users**, make sure the toggle is enabled ("Users are sent to Webhook") if you want to stream users and their properties to the webhook. When enabled, users are sent to the webhook when an event is sent to Amplitude. [Amplitude Identify API](../../analytics/apis/identify-api.md) calls are also forwarded to the webhook. Users aren't sent on a schedule or on-demand using this integration.
 
@@ -74,11 +63,11 @@ Under **Send Users**, make sure the toggle is enabled ("Users are sent to Webhoo
     1. Send the default Amplitude payload which follows the Amplitude [user format](../../analytics/apis/identify-api.md).
     2. Customize the payload using an [Apache FreeMarker](https://freemarker.apache.org/) template. [See more details below](#freemarker-templating-language).
 
-## Enable sync
+### Enable sync
 
 When satisfied with your configuration, at the top of the page toggle the **Status** to "Enabled" and click **Save**.
 
-## Amplitude's retry mechanism
+### Amplitude's retry mechanism
 
 Amplitude makes a delivery attempt first on each event or user, and then on failures, Amplitude make nine more attempts over 4 hours, regardless of the error. Amplitude also has a retry mechanism within each attempt: on 5xx errors and 429 throttling. Amplitude does attempt an immediate retry with these policies
 

--- a/docs/data/destinations/webhooks-streaming.md
+++ b/docs/data/destinations/webhooks-streaming.md
@@ -8,31 +8,36 @@ Amplitude's Webhook integration enables you to forward your Amplitude events and
 ## Use cases
 
 1. **Workflow Automation:** Webhooks are key in automating workflows and connecting disparate systems. They automatically trigger actions based on specified events or conditions. This helps streamline processes, reduce manual interventions, and boost operational efficiency. For example, create a webhook to automate the capture and recording of user consent. When a user accepts the terms of service, the webhook triggers and Amplitude logs the event, streamlining consent management and ensuring compliance and data accuracy.
+
 2. **Additional Flexibility Beyond Standard Streaming Integrations:** Webhooks provide enhanced customization and flexibility beyond standard streaming integrations, enabling real-time data exchange and tailored interactions for dynamic and responsive systems. For example, use a webhook to send specific event data from Amplitude to Braze, a use case the native Amplitude Braze streaming integration doesn't support. This involves transforming an Amplitude user property named `newsletters`, an array with `market` and `newsletter_names`, into a format suitable for Braze. Webhooks also enable you to format event data for Braze, to ensure correct processing as purchase events.
 
-## Setup
-
-### Prerequisites
+## Prerequisites
 
 To configure streaming from Amplitude to your webhook, you need the following information.
 
 - **Webhook URL** The destination URL Amplitude should use to send events and users.
 - **Header Information** You can set up to five extra headers for the webhook request.
 
-### Create a new sync
+## Authentication
+
+Webhook Event Streaming supports [Http Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). To authenticate your calls:
+
+Add an `Authorization` header with the value: `Basic <hash>` where `<hash>` is the Base64 encoded result 
+
+## Create a new sync
 
 1. In Amplitude Data, click **Catalog** and select the **Destinations** tab.
 2. In the Event Streaming section, click **Webhook**.
 3. Enter a sync name, then click **Create Sync**.
 
-### Enter webhook URL
+## Enter webhook URL
 
 Enter the URL endpoint for the webhook. For example, `https://mycompany.com/webhook`.
 Note that Amplitude doesn't have a single IP address for forwarding events and users, so ensure that your URL can receive payloads from any Amplitude hosts.
 
 See details on [Amplitude's retry mechanism](#amplitudes-retry-mechanism) in case a webhook call fails.
 
-### Select headers
+## Select headers
 
 There are two preset headers for every webhook sync:
 
@@ -45,7 +50,13 @@ After these preset headers, you can define five more headers. To create a new he
 2. Enter the header value on the right side text box
 3. A new header row appears if limit isn't reached
 
-### Configure event forwarding
+### Authentication
+
+Webhook Event Streaming supports [Http Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). To authenticate your calls:
+
+Add an `Authorization` header with the value: `Basic <hash>` where `<hash>` is the Base64 encoded result of the `username:password` values of the system the webhook connects to.
+
+## Configure event forwarding
 
 Under **Send Events**, make sure the toggle is enabled ("Events are sent to Webhook") if you want to stream events to the webhook. When enabled, events are automatically forwarded to the webhook when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration.
 
@@ -55,7 +66,7 @@ Under **Send Events**, make sure the toggle is enabled ("Events are sent to Webh
 
 2. In **Select and filter events** choose which events you want to send. Choose only the events you need in the webhook. _Transformed events aren't supported._
 
-### Configure user forwarding
+## Configure user forwarding
 
 Under **Send Users**, make sure the toggle is enabled ("Users are sent to Webhook") if you want to stream users and their properties to the webhook. When enabled, users are sent to the webhook when an event is sent to Amplitude. [Amplitude Identify API](../../analytics/apis/identify-api.md) calls are also forwarded to the webhook. Users aren't sent on a schedule or on-demand using this integration.
 
@@ -63,11 +74,11 @@ Under **Send Users**, make sure the toggle is enabled ("Users are sent to Webhoo
     1. Send the default Amplitude payload which follows the Amplitude [user format](../../analytics/apis/identify-api.md).
     2. Customize the payload using an [Apache FreeMarker](https://freemarker.apache.org/) template. [See more details below](#freemarker-templating-language).
 
-### Enable sync
+## Enable sync
 
 When satisfied with your configuration, at the top of the page toggle the **Status** to "Enabled" and click **Save**.
 
-### Amplitude's retry mechanism
+## Amplitude's retry mechanism
 
 Amplitude makes a delivery attempt first on each event or user, and then on failures, Amplitude make nine more attempts over 4 hours, regardless of the error. Amplitude also has a retry mechanism within each attempt: on 5xx errors and 429 throttling. Amplitude does attempt an immediate retry with these policies
 


### PR DESCRIPTION
# Amplitude Developer Docs PR
Update Profile API doc that for computation ID we also support it. 

On another path (prediction) it was already mentioned we supported it: https://www.docs.developers.amplitude.com/analytics/apis/user-profile-api/#get-singlemultiple-prediction-propensity --> thus for this I copy the section data to explain how multiple computations are supported. 

## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
