### PR TITLE
fix: remove javascript sdk paths from robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
 Disallow: /analytics/apis/taxonomy-import-api/
-Disallow: /data/sdks/javascript/*
 Disallow: /utils/*
-NoIndex: /data/sdks/javascript/*


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
We've added the noindex meta to the JS docs page so these attributes are no longer needed

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
