### PR TITLE
feat: add bitmap-capture-android.md to Session Replay docs

### DIFF
--- a/docs/session-replay/sdks/middleware-android.md
+++ b/docs/session-replay/sdks/middleware-android.md
@@ -152,6 +152,8 @@ if (nonEUCountryFlagEnabled) {
 }
 ```
 
+--8<-- "includes/session-replay/bitmap-capture-android.md"
+
 --8<-- "includes/session-replay/data-retention.md"
 
 --8<-- "includes/session-replay/replay-storage-android.md"

--- a/docs/session-replay/sdks/plugin-android.md
+++ b/docs/session-replay/sdks/plugin-android.md
@@ -167,6 +167,8 @@ if (nonEUCountryFlagEnabled) {
 }
 ```
 
+--8<-- "includes/session-replay/bitmap-capture-android.md"
+
 --8<-- "includes/session-replay/data-retention.md"
 
 --8<-- "includes/session-replay/replay-storage-android.md"

--- a/docs/session-replay/sdks/standalone-android.md
+++ b/docs/session-replay/sdks/standalone-android.md
@@ -162,6 +162,8 @@ if (nonEUCountryFlagEnabled) {
 }
 ```
 
+--8<-- "includes/session-replay/bitmap-capture-android.md"
+
 --8<-- "includes/session-replay/data-retention.md"
 
 --8<-- "includes/session-replay/replay-storage-android.md"

--- a/includes/session-replay/bitmap-capture-android.md
+++ b/includes/session-replay/bitmap-capture-android.md
@@ -1,0 +1,10 @@
+### Bitmap Capture
+
+!!!info "Bitmap Capture is disabled by default"
+    Enabling bitmap capture may greatly increase the amount of CPU and memory used by the Session Replay SDK. This performance will be improved in future releases.
+
+To enable bitmap capture, use one or more of the following
+
+1. Set a `internalOptions.bitmapViewFilter`. E.g. `SessionReplay(internalOptions=InternalOptions(bitmapViewFilter = ViewFilters.ImageViewFilter()))`.
+2. In Android XML, add `android:tag="amp-bitmap""` to your view. E.g. `<View android:tag="amp-bitmap"></View>`
+3. In Compose layouts, add a `Modifier.ampBitmap()` to the view `modifiers`. E.g. `           Checkbox(checked = true, modifier = Modifier.ampBitmap())`

--- a/includes/session-replay/bitmap-capture-android.md
+++ b/includes/session-replay/bitmap-capture-android.md
@@ -5,6 +5,6 @@
 
 To enable bitmap capture, use one or more of the following
 
-1. Set a `internalOptions.bitmapViewFilter`. E.g. `SessionReplay(internalOptions=InternalOptions(bitmapViewFilter = ViewFilters.ImageViewFilter()))`.
+1. Set a `internalOptions.bitmapViewFilter`. For example, `SessionReplay(internalOptions=InternalOptions(bitmapViewFilter = ViewFilters.ImageViewFilter()))`.
 2. In Android XML, add `android:tag="amp-bitmap""` to your view. E.g. `<View android:tag="amp-bitmap"></View>`
 3. In Compose layouts, add a `Modifier.ampBitmap()` to the view `modifiers`. E.g. `           Checkbox(checked = true, modifier = Modifier.ampBitmap())`

--- a/includes/session-replay/bitmap-capture-android.md
+++ b/includes/session-replay/bitmap-capture-android.md
@@ -1,7 +1,7 @@
 ### Bitmap Capture
 
 !!!info "Bitmap Capture is disabled by default"
-    Enabling bitmap capture may greatly increase the amount of CPU and memory used by the Session Replay SDK. This performance will be improved in future releases.
+    Enabling bitmap capture may increase the amount of CPU and memory used by the Session Replay SDK. This performance will be improved in future releases.
 
 To enable bitmap capture, use one or more of the following
 

--- a/includes/session-replay/bitmap-capture-android.md
+++ b/includes/session-replay/bitmap-capture-android.md
@@ -6,5 +6,5 @@
 To enable bitmap capture, use one or more of the following
 
 1. Set a `internalOptions.bitmapViewFilter`. For example, `SessionReplay(internalOptions=InternalOptions(bitmapViewFilter = ViewFilters.ImageViewFilter()))`.
-2. In Android XML, add `android:tag="amp-bitmap""` to your view. E.g. `<View android:tag="amp-bitmap"></View>`
+2. In Android XML, add `android:tag="amp-bitmap""` to your view. For example,  `<View android:tag="amp-bitmap"></View>`
 3. In Compose layouts, add a `Modifier.ampBitmap()` to the view `modifiers`. E.g. `           Checkbox(checked = true, modifier = Modifier.ampBitmap())`

--- a/includes/session-replay/bitmap-capture-android.md
+++ b/includes/session-replay/bitmap-capture-android.md
@@ -7,4 +7,4 @@ To enable bitmap capture, use one or more of the following
 
 1. Set a `internalOptions.bitmapViewFilter`. For example, `SessionReplay(internalOptions=InternalOptions(bitmapViewFilter = ViewFilters.ImageViewFilter()))`.
 2. In Android XML, add `android:tag="amp-bitmap""` to your view. For example,  `<View android:tag="amp-bitmap"></View>`
-3. In Compose layouts, add a `Modifier.ampBitmap()` to the view `modifiers`. E.g. `           Checkbox(checked = true, modifier = Modifier.ampBitmap())`
+3. In Compose layouts, add a `Modifier.ampBitmap()` to the view `modifiers`. For example, `           Checkbox(checked = true, modifier = Modifier.ampBitmap())`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,7 +159,7 @@ extra:
   generator: false #hides the generated with text in the footer
   android:
     session_replay:
-      version: 0.5+
+      version: 0.6+
   browser:
     session_replay:
       plugin:


### PR DESCRIPTION
## Description

* Add Bitmap capture instructions to Android SR docs

<img width="796" alt="image" src="https://github.com/amplitude/amplitude-dev-center/assets/5790872/0a8b3f68-6009-4e1e-b39f-4afb02e27c58">
