### PR TITLE
AMP-96489 Add new docs for lookup table apis v3

### DIFF
--- a/docs/analytics/apis/lookup-tables-api.md
+++ b/docs/analytics/apis/lookup-tables-api.md
@@ -4,7 +4,7 @@ description: The Lookup Table API lets you create, get, update, and delete looku
 ---
 
 !!!deprecated "This version of the Lookup Tables API is deprecated"
-    Please use the new [API](/data/sources/lookup-table). This API will be sunset in the future.
+    This API is no longer supported. Use the new [API](/data/sources/lookup-table). 
 
 !!!beta "This feature is in beta"
     This requires that you have the `lookup_table` feature enabled in Amplitude. Contact your Amplitude account manager if you need help.

--- a/docs/analytics/apis/lookup-tables-api.md
+++ b/docs/analytics/apis/lookup-tables-api.md
@@ -4,7 +4,7 @@ description: The Lookup Table API lets you create, get, update, and delete looku
 ---
 
 !!!deprecated "This version of the Lookup Tables API is deprecated"
-    This API is no longer supported. Use the new [API](/data/sources/lookup-table). 
+    This API is no longer supported. Use the new [API](/data/apis/lookup-tables-api). 
 
 !!!beta "This feature is in beta"
     This requires that you have the `lookup_table` feature enabled in Amplitude. Contact your Amplitude account manager if you need help.

--- a/docs/analytics/apis/lookup-tables-api.md
+++ b/docs/analytics/apis/lookup-tables-api.md
@@ -3,8 +3,11 @@ title: Lookup Table API
 description: The Lookup Table API lets you create, get, update, and delete lookup tables to augment your data.
 ---
 
+!!!deprecated "This version of the Lookup Tables API is deprecated"
+    Please use the new [API](/data/sources/lookup-table). This API will be sunset in the future.
+
 !!!beta "This feature is in beta"
-        This requires that you have the `lookup_table` feature enabled in Amplitude. Contact your Amplitude account manager if you need help.
+    This requires that you have the `lookup_table` feature enabled in Amplitude. Contact your Amplitude account manager if you need help.
 
 Lookup tables let you augment user and event properties. Instead of using formulas, you can upload a CSV file that contains property mappings to derive new properties. 
 

--- a/docs/data/apis/lookup-tables-api.md
+++ b/docs/data/apis/lookup-tables-api.md
@@ -175,9 +175,9 @@ Retrieve a Lookup Table by its name.
     }
     ```
 
-## Download Lookup Table CSV
+## Download CSV
 
-Download the lookup table object as a CSV. Any incremental changes that have been made will be applied in the downloaded file
+Download the lookup table object as a CSV. Any incremental changes that have been made are applied in the downloaded file
 
 ### Parameters
 
@@ -204,7 +204,7 @@ Download the lookup table object as a CSV. Any incremental changes that have bee
 
 ## Override a Lookup Table
 
-Replace a Lookup Table object by uploading a CSV that will replace the CSV already uploaded to Amplitude. Send the request with the type multipart/form-data type.
+Override a Lookup Table object by uploading a CSV that replaces the CSV already uploaded to Amplitude. Send the request with the type multipart/form-data type.
 
 ### Parameters
 
@@ -281,7 +281,7 @@ Replace a Lookup Table object by uploading a CSV that will replace the CSV alrea
 
 ## Update a Lookup Table
 
-Update a Lookup Table's columns and data. If a CSV file is provided, it will merge with the existing CSV within Amplitude. This allows for incremental updates of the CSV, instead of a complete replacement. A property can also be provided to update the mapped property in Amplitude.
+Update a Lookup Table's columns and data. If a CSV file is provided, it is merged with the existing CSV within Amplitude. This allows for incremental updates of the CSV, instead of a complete replacement. If a property is provided, it updates the mapped property of the table.
 
 ### Parameters
 
@@ -469,16 +469,16 @@ List all the Lookup Tables for the project.
 
 ## Error Codes
 
-All of the above lookup table apis share common error codes as described below.
+All the above lookup table APIs share common error codes as described below.
 
 ### Structure
 
 |<div class="big-column">Name</div>| Description|
 |-----|------|
-|`statusCode` | HTTP Status code of error. 400, 409, 413 |
+|`statusCode` | Http status code of error. 400, 409, 413 |
 |`message` | Human readable message describing the error | 
 |`errorCode` | Static error code string |
-|`extraParams`| Each error might have extra params in the response to help better point to the exact reason for the error|
+|`extraParams`| Each error might have extra parameters in the response to help better point to the exact reason for the error|
 
 ### Types
 
@@ -486,15 +486,15 @@ All of the above lookup table apis share common error codes as described below.
 |-----|------|
 |LOOKUP_TABLE_INVALID_FILE_COUNT| Attempted to upload more than 1 file for a single lookup table.|
 |LOOKUP_TABLE_INVALID_FILE_SIZE | Created/Edited a lookup table using a file bigger than 100mb. |
-|LOOKUP_TABLE_INVALID_FILE_TYPE| Created/Edited a lookup table using a file that was not a CSV. |
+|LOOKUP_TABLE_INVALID_FILE_TYPE| Created/Edited a lookup table using a file that wasn't a CSV. |
 |LOOKUP_TABLE_INVALID_KEY_COLUMN| Created a lookup table with a "key" input not present in the headers of the table.|
 |LOOKUP_TABLE_INVALID_VALUE_COLUMN| Cell in uploaded file exceeds 1,024 characters. |
-|LOOKUP_TABLE_INVALID_KEY_PROPERTY| Provided key property does not exist in Amplitude. |
+|LOOKUP_TABLE_INVALID_KEY_PROPERTY| Provided key property doesn't exist in Amplitude. |
 |LOOKUP_TABLE_INVALID_NUMBER_OF_ROWS| Created/Edited a lookup table using a file with more than 1mil rows.|
 |LOOKUP_TABLE_KEY_COLUMN_DUPLICATE_VALUES| Specified key column has duplicate values.|
 |LOOKUP_TABLE_INVALID_TABLE_NAME| Provided name is invalid.|
-|LOOKUP_TABLE_MALFORMED_CSV| Provided CSV could not be processed correctly. See error message for more details.|
-|LOOKUP_TABLE_INVALID_INPUT| Input for field does not match expectation. See error message for more details.|
+|LOOKUP_TABLE_MALFORMED_CSV| Provided CSV couldn't be processed correctly. See error message for more details.|
+|LOOKUP_TABLE_INVALID_INPUT| Input for field doesn't match expectation. See error message for more details.|
 |LOOKUP_TABLE_ALREADY_EXISTS| Created a table that already exists in the provided project.|
-|LOOKUP_TABLE_DOES_NOT_EXIST| Attempted to load or edit table that does not exist.|
-|LOOKUP_TABLE_INVALID_COLUMN_HEADERS| Column headers in file could not be processed.|
+|LOOKUP_TABLE_DOES_NOT_EXIST| Attempted to load or edit table that doesn't exist.|
+|LOOKUP_TABLE_INVALID_COLUMN_HEADERS| Column headers in file couldn't be processed.|

--- a/docs/data/apis/lookup-tables-api.md
+++ b/docs/data/apis/lookup-tables-api.md
@@ -5,7 +5,7 @@ description: The Lookup Table API lets you create, get, update, and delete looku
 
 Lookup tables let you augment user and event properties. Instead of using formulas, you can upload a CSV file that contains property mappings to derive new properties. 
 
-To create a lookup property, create a lookup table to reference. You can retrieve and update each of the tables using the API. Lookup Tables are identified by the name and are scoped per project.
+To create a lookup property, create a lookup table to reference. You can retrieve and update each of the tables using the API. Lookup Tables have unique names and have a project scope.
 
 You can also create and manage lookup tables from the Amplitude web app. See [Lookup Table](/data/sources/lookup-table) for more information.
 
@@ -22,13 +22,13 @@ You can also create and manage lookup tables from the Amplitude web app. See [Lo
 
 ## Considerations
 
-The CSV file must comply with the following requirements:
+The CSV file must follow the following requirements:
 
 - The max file size is 100 MB and the file can't have more than 1,000,000 rows.
 - The first row must contain column names/headers.
 - The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
-- Columns must be separated by commas.
-- Rows must be separated by line breaks.
+- Columns are separated by commas.
+- Rows are separated by line breaks.
 - If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by two double quotes `""`.
 
 ## Create a Lookup Table
@@ -175,9 +175,9 @@ Retrieve a Lookup Table by its name.
     }
     ```
 
-## Download CSV
+## Download csv
 
-Download the lookup table object as a CSV. Any incremental changes that have been made are applied in the downloaded file
+Download the lookup table object as a CSV. Any incremental changes are applied in the downloaded file
 
 ### Parameters
 
@@ -281,7 +281,7 @@ Override a Lookup Table object by uploading a CSV that replaces the CSV already 
 
 ## Update a Lookup Table
 
-Update a Lookup Table's columns and data. If a CSV file is provided, it is merged with the existing CSV within Amplitude. This allows for incremental updates of the CSV, instead of a complete replacement. If a property is provided, it updates the mapped property of the table.
+Update a Lookup Table's columns and data. If a CSV file is provided, the file is merged with the existing CSV within Amplitude. This allows for incremental updates of the CSV, instead of a complete replacement.
 
 ### Parameters
 
@@ -493,8 +493,8 @@ All the above lookup table APIs share common error codes as described below.
 |LOOKUP_TABLE_INVALID_NUMBER_OF_ROWS| Created/Edited a lookup table using a file with more than 1mil rows.|
 |LOOKUP_TABLE_KEY_COLUMN_DUPLICATE_VALUES| Specified key column has duplicate values.|
 |LOOKUP_TABLE_INVALID_TABLE_NAME| Provided name is invalid.|
-|LOOKUP_TABLE_MALFORMED_CSV| Provided CSV couldn't be processed correctly. See error message for more details.|
+|LOOKUP_TABLE_MALFORMED_CSV| Provided CSV not processed correctly. See error message for more details.|
 |LOOKUP_TABLE_INVALID_INPUT| Input for field doesn't match expectation. See error message for more details.|
 |LOOKUP_TABLE_ALREADY_EXISTS| Created a table that already exists in the provided project.|
 |LOOKUP_TABLE_DOES_NOT_EXIST| Attempted to load or edit table that doesn't exist.|
-|LOOKUP_TABLE_INVALID_COLUMN_HEADERS| Column headers in file couldn't be processed.|
+|LOOKUP_TABLE_INVALID_COLUMN_HEADERS| Column headers in file not processed correctly.|

--- a/docs/data/apis/lookup-tables-api.md
+++ b/docs/data/apis/lookup-tables-api.md
@@ -1,0 +1,500 @@
+---
+title: Lookup Table API
+description: The Lookup Table API lets you create, get, update, and delete lookup tables to augment your data.
+---
+
+Lookup tables let you augment user and event properties. Instead of using formulas, you can upload a CSV file that contains property mappings to derive new properties. 
+
+To create a lookup property, create a lookup table to reference. You can retrieve and update each of the tables using the API. Lookup Tables are identified by the name and are scoped per project.
+
+You can also create and manage lookup tables from the Amplitude web app. See [Lookup Table](/data/sources/lookup-table) for more information.
+
+--8<-- "includes/postman.md"
+
+## Endpoints
+
+| Region | Endpoint |
+| --- | --- |
+| Standard Server | https://data-api.amplitude.com/api/3/lookup_table |
+| EU Residency Server | https://data-api.eu.amplitude.com/api/3/lookup_table |
+
+--8<-- "includes/auth-basic.md"
+
+## Considerations
+
+The CSV file must comply with the following requirements:
+
+- The max file size is 100 MB and the file can't have more than 1,000,000 rows.
+- The first row must contain column names/headers.
+- The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
+- Columns must be separated by commas.
+- Rows must be separated by line breaks.
+- If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by two double quotes `""`.
+
+## Create a Lookup Table
+
+Create a Lookup Table object by uploading a CSV that maps an existing property to the new properties to create. Send the request with the type multipart/form-data type.
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|------|-----|
+|`name`     | <span class="required">Required</span>| String| Name of the table.|
+|`file`     | <span class="required">Required</span>| File| A CSV representation of the mappings.|
+|`key`      | <span class="required">Required</span>| String| Column in CSV to use as key of lookup table.|
+|`property` | <span class="required">Required</span>| JSON| Property in Amplitude to map to the key column in CSV.|
+|`property.value` | <span class="required">Required</span>| String| Name of property in Amplitude.|
+|`property.type` | <span class="required">Required</span>| String| Type of property in Amplitude.|
+|`property.groupType` | |String| Required only if property is a group property.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X POST 'https://data-api.amplitude.com/api/3/lookup_table' \
+         -u API_KEY:SECRET_KEY \
+         -F 'file=@"/path/to/file.csv"' \
+         -F 'name=":name"' \
+         -F 'key=":key"' \
+         -F 'property="{\"value\": \":propertyName\", \"type\": \":propertyType\", \"groupType\":  \":propertyGroupType\"}";type=application/json'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    POST '/api/3/lookup_table' HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name="key"
+
+    :key
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name="name"
+
+    :name
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name=":name"; filename="file.csv"
+    Content-Type: text/csv
+
+    (data)
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name="property"
+    Content-Type: application/json
+
+    {"value": ":propertyName", "type": ":propertyType", "groupType": ":propertyGroupType"}
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    
+    ```
+
+### Responses
+
+=== "Success"
+
+    ```json
+    {
+        "appId": "<projectId>",
+        "name": "example-lookup",
+        "columnHeaders": [
+            "Language"
+        ],
+        "createdAt": 1715912516,
+        "createdBy": "api",
+        "lastModifiedAt": 1715912516,
+        "lastModifiedBy": "api",
+        "isDeleted": false,
+        "isConfigured": true,
+        "keyColumnHeader": "SKU",
+        "keyProperty": {
+            "type": "event",
+            "value": "example",
+            "groupType": "User"
+        },
+        "fileName": "lookup-table-example.csv",
+        "rowCount": 3,
+        "sizeBytes": 0,
+    }
+    ```
+
+## Retrieve a Lookup Table
+
+Retrieve a Lookup Table by its name.
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|----|----|
+|`name` | <span class="required">Required</span>| String| Name of the table.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X GET 'https://data-api.amplitude.com/api/3/lookup_table/:name' \
+         -u API_KEY:SECRET_KEY
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /api/3/lookup_table/:name HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    ```
+
+### Response
+
+=== "Success"
+
+    ```json
+    {
+        "appId": "<projectId>",
+        "name": "example-lookup",
+        "columnHeaders": [
+            "Language"
+        ],
+        "createdAt": 1715912516,
+        "createdBy": "api",
+        "lastModifiedAt": 1715912516,
+        "lastModifiedBy": "api",
+        "isDeleted": false,
+        "isConfigured": true,
+        "keyColumnHeader": "SKU",
+        "keyProperty": {
+            "type": "event",
+            "value": "example",
+            "groupType": "User"
+        },
+        "fileName": "lookup-table-example.csv",
+        "rowCount": 3,
+        "sizeBytes": 5,
+    }
+    ```
+
+## Download Lookup Table CSV
+
+Download the lookup table object as a CSV. Any incremental changes that have been made will be applied in the downloaded file
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|----|----|
+|`name` | <span class="required">Required</span>| String| Name of the table.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X GET 'https://data-api.amplitude.com/api/3/lookup_table/:name/csv' \
+         -u API_KEY:SECRET_KEY
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /api/3/lookup_table/:name/csv HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    ```
+
+## Override a Lookup Table
+
+Replace a Lookup Table object by uploading a CSV that will replace the CSV already uploaded to Amplitude. Send the request with the type multipart/form-data type.
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|------|-----|
+|`name`     | <span class="required">Required</span>| String| Name of the table.|
+|`file`     | | File| A CSV representation of the mappings.|
+|`property` | | JSON| Property in Amplitude to map to the key column in CSV.|
+|`property.value` | | String| Name of property in Amplitude.|
+|`property.type` | | String| Type of property in Amplitude.|
+|`property.groupType` | |String| Required only if property is a group property.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X PUT 'https://data-api.amplitude.com/api/3/lookup_table/:name' \
+         -u API_KEY:SECRET_KEY \
+         -F 'file=@"/path/to/file.csv"' \
+         -F 'property="{\"value\": \":propertyName\", \"type\": \":propertyType\", \"groupType\":  \":propertyGroupType\"}";type=application/json'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    PUT '/api/3/lookup_table/:name' HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name=":name"; filename="file.csv"
+    Content-Type: text/csv
+
+    (data)
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name="property"
+    Content-Type: application/json
+
+    {"value": ":propertyName", "type": ":propertyType", "groupType": ":propertyGroupType"}
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    
+    ```
+
+### Responses
+
+=== "Success"
+
+    ```json
+    {
+        "appId": "<projectId>",
+        "name": "example-lookup",
+        "columnHeaders": [
+            "Language"
+        ],
+        "createdAt": 1715912516,
+        "createdBy": "api",
+        "lastModifiedAt": 1715912516,
+        "lastModifiedBy": "api",
+        "isDeleted": false,
+        "isConfigured": true,
+        "keyColumnHeader": "SKU",
+        "keyProperty": {
+            "type": "event",
+            "value": "example",
+            "groupType": "User"
+        },
+        "fileName": "lookup-table-example.csv",
+        "rowCount": 3,
+        "sizeBytes": 0,
+    }
+    ```
+
+## Update a Lookup Table
+
+Update a Lookup Table's columns and data. If a CSV file is provided, it will merge with the existing CSV within Amplitude. This allows for incremental updates of the CSV, instead of a complete replacement. A property can also be provided to update the mapped property in Amplitude.
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|------|-----|
+|`name`     | <span class="required">Required</span>| String| Name of the table.|
+|`file`     | | File| A CSV representation of the mappings.|
+|`property` | | JSON| Property in Amplitude to map to the key column in CSV.|
+|`property.value` | | String| Name of property in Amplitude.|
+|`property.type` | | String| Type of property in Amplitude.|
+|`property.groupType` | |String| Required only if property is a group property.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X PATCH 'https://data-api.amplitude.com/api/3/lookup_table/:name' \
+         -u API_KEY:SECRET_KEY
+         -F 'file=@"/path/to/file.csv"' \
+         -F 'property="{\"value\": \":propertyName\", \"type\": \":propertyType\", \"groupType\":  \":propertyGroupType\"}";type=application/json'
+    ```
+=== "HTTP"
+
+    ```bash
+    PATCH '/api/3/lookup_table/:name' HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name=":name"; filename="file.csv"
+    Content-Type: text/csv
+
+    (data)
+    ----WebKitFormBoundary7MA4YWxkTrZu0gW
+    Content-Disposition: form-data; name="property"
+    Content-Type: application/json
+
+    {"value": ":propertyName", "type": ":propertyType", "groupType": ":propertyGroupType"}
+    ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    
+    ```
+
+### Response
+
+=== "Success"
+
+    ```json
+    {
+        "appId": "<projectId>",
+        "name": "example-lookup",
+        "columnHeaders": [
+            "Language"
+        ],
+        "createdAt": 1715912516,
+        "createdBy": "api",
+        "lastModifiedAt": 1715912516,
+        "lastModifiedBy": "api",
+        "isDeleted": false,
+        "isConfigured": true,
+        "keyColumnHeader": "SKU",
+        "keyProperty": {
+            "type": "event",
+            "value": "example",
+            "groupType": "User"
+        },
+        "fileName": "lookup-table-example.csv",
+        "rowCount": 3,
+        "sizeBytes": 0,
+    }
+    ```
+
+## Delete a Lookup Table
+
+Delete a Lookup Table.
+
+### Parameters
+
+|<div class="big-column">Name</div>| Required| Type| Description|
+|-----|------|----|----|
+|`name` | <span class="required">Required</span>| String| Name of the table.|
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X DELETE 'https://data-api.amplitude.com/api/3/lookup_table/:name' \
+         -u API_KEY:SECRET_KEY
+    ```
+
+=== "HTTP"
+
+    ```bash
+    DELETE /api/3/lookup_table/:name HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret-key}}
+    ```
+
+### Response
+
+=== "Success"
+
+    ```json
+    {
+        "message": "Lookup table <:name> deleted successfully",
+        "success": true
+    }
+    ```
+
+## List all Lookup Tables
+
+List all the Lookup Tables for the project.
+
+### Example request
+
+=== "cURL"
+
+    ```curl
+    curl -L -X GET 'https://data-api.amplitude.com/api/3/lookup_table' \
+         -u API_KEY:SECRET_KEY
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /api/3/lookup_table HTTP/1.1
+    Host: data-api.amplitude.com
+    Authorization: Basic {{api-key}}:{{secret:key}}
+    ```
+
+### Response
+
+=== "Success"
+
+    ```json
+    [
+        {
+            "appId": "<projectId>",
+            "name": "example-lookup",
+            "columnHeaders": [
+                "Language"
+            ],
+            "createdAt": 1715912516,
+            "createdBy": "api",
+            "lastModifiedAt": 1715912516,
+            "lastModifiedBy": "api",
+            "isDeleted": false,
+            "isConfigured": true,
+            "keyColumnHeader": "SKU",
+            "keyProperty": {
+                "type": "event",
+                "value": "example",
+                "groupType": "User"
+            },
+            "fileName": "lookup-table-example.csv",
+            "rowCount": 3,
+            "sizeBytes": 5,
+        },
+        {
+            "appId": "<projectId>",
+            "name": "example-lookup-2",
+            "columnHeaders": [
+                "Language"
+            ],
+            "createdAt": 1715912516,
+            "createdBy": "api",
+            "lastModifiedAt": 1715912516,
+            "lastModifiedBy": "api",
+            "isDeleted": false,
+            "isConfigured": true,
+            "keyColumnHeader": "SKU",
+            "keyProperty": {
+                "type": "event",
+                "value": "example",
+                "groupType": "User"
+            },
+            "fileName": "lookup-table-example.csv",
+            "rowCount": 50,
+            "sizeBytes": 10,
+        }
+    ]
+    ```
+
+## Error Codes
+
+All of the above lookup table apis share common error codes as described below.
+
+### Structure
+
+|<div class="big-column">Name</div>| Description|
+|-----|------|
+|`statusCode` | HTTP Status code of error. 400, 409, 413 |
+|`message` | Human readable message describing the error | 
+|`errorCode` | Static error code string |
+|`extraParams`| Each error might have extra params in the response to help better point to the exact reason for the error|
+
+### Types
+
+|<div class="big-column">Code</div>| Description|
+|-----|------|
+|LOOKUP_TABLE_INVALID_FILE_COUNT| Attempted to upload more than 1 file for a single lookup table.|
+|LOOKUP_TABLE_INVALID_FILE_SIZE | Created/Edited a lookup table using a file bigger than 100mb. |
+|LOOKUP_TABLE_INVALID_FILE_TYPE| Created/Edited a lookup table using a file that was not a CSV. |
+|LOOKUP_TABLE_INVALID_KEY_COLUMN| Created a lookup table with a "key" input not present in the headers of the table.|
+|LOOKUP_TABLE_INVALID_VALUE_COLUMN| Cell in uploaded file exceeds 1,024 characters. |
+|LOOKUP_TABLE_INVALID_KEY_PROPERTY| Provided key property does not exist in Amplitude. |
+|LOOKUP_TABLE_INVALID_NUMBER_OF_ROWS| Created/Edited a lookup table using a file with more than 1mil rows.|
+|LOOKUP_TABLE_KEY_COLUMN_DUPLICATE_VALUES| Specified key column has duplicate values.|
+|LOOKUP_TABLE_INVALID_TABLE_NAME| Provided name is invalid.|
+|LOOKUP_TABLE_MALFORMED_CSV| Provided CSV could not be processed correctly. See error message for more details.|
+|LOOKUP_TABLE_INVALID_INPUT| Input for field does not match expectation. See error message for more details.|
+|LOOKUP_TABLE_ALREADY_EXISTS| Created a table that already exists in the provided project.|
+|LOOKUP_TABLE_DOES_NOT_EXIST| Attempted to load or edit table that does not exist.|
+|LOOKUP_TABLE_INVALID_COLUMN_HEADERS| Column headers in file could not be processed.|

--- a/docs/data/apis/lookup-tables-api.md
+++ b/docs/data/apis/lookup-tables-api.md
@@ -5,7 +5,7 @@ description: The Lookup Table API lets you create, get, update, and delete looku
 
 Lookup tables let you augment user and event properties. Instead of using formulas, you can upload a CSV file that contains property mappings to derive new properties. 
 
-To create a lookup property, create a lookup table to reference. You can retrieve and update each of the tables using the API. Lookup Tables have unique names and have a project scope.
+To create a lookup property, create a Lookup Table to reference. You can retrieve and update each of the tables using the API. Lookup Tables have unique names and have a project scope.
 
 You can also create and manage lookup tables from the Amplitude web app. See [Lookup Table](/data/sources/lookup-table) for more information.
 
@@ -29,7 +29,7 @@ The CSV file must follow the following requirements:
 - The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
 - Columns are separated by commas.
 - Rows are separated by line breaks.
-- If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by two double quotes `""`.
+- If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by double quotes.
 
 ## Create a Lookup Table
 

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -30,7 +30,7 @@ To set up this integration, you need the following:
 
 1. In Amplitude Data, click **Catalog** and select the **Sources** tab.
 2. In the Lookup Tables section, click **CSV**.
-3. Select column in CSV to map property to.
+3. Select column in CSV as the key column.
 4. Map your property.
 5. When you're done mapping, click **Finish**.
 

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -30,8 +30,8 @@ To set up this integration, you need the following:
 
 1. In Amplitude Data, click **Catalog** and select the **Sources** tab.
 2. In the Lookup Tables section, click **CSV**.
-3. Upload the CSV then click **Next**.
-4. Map your event property.
+3. Select column in CSV to map property to.
+4. Map your property.
 5. When you're done mapping, click **Finish**.
 
 ## Update a lookup table
@@ -39,18 +39,16 @@ To set up this integration, you need the following:
 If you want to create a new lookup property or that mapped property is wrong, you can update the lookup table.
 
 1. In Amplitude, navigate to Data Sources, then find the lookup table in the Sources table.
-2. Click the **Edit Lookup Table Configuration** tab.
-3. Make your changes. You can change the mapping, or replace the CSV by uploading a new one.
-4. When finished, click **Update your lookup table configuration**.
+2. Make your changes. You can change the mapping, or replace the CSV by uploading a new one.
+3. When finished, click **Save Changes**.
 
 ## Delete the lookup table and its properties
 
 When you no longer need a lookup table, you can delete it.
 
 1. In Amplitude, navigate to Data Sources, then find the lookup table in the Sources table.
-2. Click the **Edit Lookup Table Configuration** tab.
-3. Click the trash icon.
-4. Follow the on-screen instructions.
+2. Click the trash icon.
+3. Follow the on-screen instructions.
 
 ## Lookup table use cases
 

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -24,7 +24,7 @@ To set up this integration, you need the following:
     - The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
     - Columns must be separated by commas.
     - Rows must be separated by line breaks.
-    - If a field value contains commas or quotes, wrap the contents with double quotation marks (`"`). The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by double quotes.
+    - If a field value contains commas or quotes, wrap the contents with double quotation marks (`"`). The first double quote signifies the beginning of the column data, and the last double quote marks the end. If a string contains double quotes, replace them with single quotes.
 
 ### Amplitude setup
 

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -24,7 +24,7 @@ To set up this integration, you need the following:
     - The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
     - Columns must be separated by commas.
     - Rows must be separated by line breaks.
-    - If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by double quotes.
+    - If a field value contains commas or quotes, wrap the contents with double quotation marks (`"`). The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by double quotes.
 
 ### Amplitude setup
 

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -24,13 +24,13 @@ To set up this integration, you need the following:
     - The first column must correspond to the mapping property value and must contain *unique* values. Lookup Tables search for exact matches, and are *case-sensitive*.
     - Columns must be separated by commas.
     - Rows must be separated by line breaks.
-    - If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by two double quotes `""`.
+    - If a field value contains commas or quotes, it should be wrapped within double quotation marks. The first double quote signifies the beginning of the column data, and the last double quote marks the end. If the value contains a string with double quotes, these are replaced by double quotes.
 
 ### Amplitude setup
 
 1. In Amplitude Data, click **Catalog** and select the **Sources** tab.
 2. In the Lookup Tables section, click **CSV**.
-3. Select column in CSV as the key column.
+3. Select a column in the CSV to be the key column.
 4. Map your property.
 5. When you're done mapping, click **Finish**.
 

--- a/includes/api-table-analytics.md
+++ b/includes/api-table-analytics.md
@@ -11,7 +11,8 @@
 |[Group Identify](../apis/group-identify-api)|Set or update properties of particular groups.|
 |[HTTP V2](../apis/http-v2-api)|Send data directly from your server to the HTTP V2 endpoint.|
 |[Identify](../apis/identify-api)|Set the User ID for a particular Device ID or update user properties of a particular user without sending an event.|
-|[Lookup Tables](../apis/lookup-tables-api)|Augment your properties with static data.|
+|[Lookup Tables (deprecated)](../apis/lookup-tables-api)|Augment your properties with static data.|
+|[Lookup Tables (v3)](/data/apis/lookup-tables-api)|Augment your properties with static data.|
 |[Releases](../apis/releases-api)|Programmatically create releases in Amplitude using the Releases API. |
 |[SCIM](../apis/scim-api)|Provision and manage users and groups. This API uses the System for Cross-domain Identity Management (SCIM) 2.0 Standard.|
 |[Taxonomy](../apis/taxonomy-api)|Create, get, update, and delete categories, event types, event properties, and user properties.|

--- a/includes/auth-basic.md
+++ b/includes/auth-basic.md
@@ -7,4 +7,4 @@ Your authorization header should look something like this:
 `--header 'Authorization: Basic YWhhbWwsdG9uQGFwaWdlZS5jb206bClwYXNzdzByZAo'`
 
 
-See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 
+See [Find your Amplitude Project API Credentials](/analytics/find-api-credentials/) for help locating your credentials. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -511,6 +511,7 @@ nav:
       - Reference: analytics/apis/http-v2-api.md
     - Identify: analytics/apis/identify-api.md
     - Lookup Tables (Deprecated): analytics/apis/lookup-tables-api.md
+    - Lookup Tables (v3): data/apis/lookup-tables-api.md
     - Releases: analytics/apis/releases-api.md
     - SCIM: analytics/apis/scim-api.md
     - Taxonomy: analytics/apis/taxonomy-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -414,6 +414,8 @@ nav:
       - DataGrail: data/pii/datagrail.md
       - Osano: data/pii/osano.md
       - Transcend: data/pii/transcend.md
+    - Rest APIs:
+      - Lookup Tables: data/apis/lookup-tables-api.md
     - Time-to-Live: data/ttl-configuration.md
   - Experiment:
       - experiment/index.md
@@ -508,7 +510,7 @@ nav:
       - Quickstart: analytics/apis/http-v2-api-quickstart.md
       - Reference: analytics/apis/http-v2-api.md
     - Identify: analytics/apis/identify-api.md
-    - Lookup Tables: analytics/apis/lookup-tables-api.md
+    - Lookup Tables (Deprecated): analytics/apis/lookup-tables-api.md
     - Releases: analytics/apis/releases-api.md
     - SCIM: analytics/apis/scim-api.md
     - Taxonomy: analytics/apis/taxonomy-api.md


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description
Added docs for the new Lookup Table API V3, which is under data-api, so moved to the Data section.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [X] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
