### PR TITLE
Update SR Plugin with Promise to GTM doc

### DIFF
--- a/docs/session-replay/tag-managers/google-tag-manager.md
+++ b/docs/session-replay/tag-managers/google-tag-manager.md
@@ -36,9 +36,7 @@ Instrumenting Amplitude Session Replay with Google Tag Manager requires a differ
     loadAsync("https://cdn.amplitude.com/libs/plugin-session-replay-browser-@{$ browser.session_replay.plugin.version $}-min.js.gz", 
       function () {
         var sessionReplayTracking = window.sessionReplay.plugin({sampleRate: 1});
-        window.amplitude.add(sessionReplayTracking).promise.then(function() {
-           console.log("Session Replay plugin loaded");
-      });
+        window.amplitude.add(sessionReplayTracking).promise;
     });
 
 </script>

--- a/docs/session-replay/tag-managers/google-tag-manager.md
+++ b/docs/session-replay/tag-managers/google-tag-manager.md
@@ -6,11 +6,12 @@ Instrumenting Amplitude Session Replay with Google Tag Manager requires a differ
 
 1. Add the [Google Tag Manager Web Template for Amplitude Analytics Browser SDK](/data/sources/google-tag-manager-client/) if it's not yet enabled.
 2. In Google Tag Manager, create an **init** tag with the same API key as your Amplitude Project. This is the project that receives the session replays.
-   1. Set the **Trigger** to `Initialization - All Pages`.
+   1. Set the **Trigger** to `Initialization`.
    2. Amplitude recommends that you enable default event tracking for better search support with Session Replay. Default events count against your event quota.
 3. Create a **Custom HTML** tag for Session Replay, and paste the code shown below.
-4. Set **Trigger** for the Session Replay Tag to `Initialization - All Pages`.
-5. Deploy the tags. Replays should begin to appear on the home page of the Amplitude app. Ensure that you're looking at the correct project.
+4. Set **Trigger** for the Session Replay Tag to `Initialization`.
+5. Sequence the Amplitude Initialization Tag to fire **after** the Session Replay tag. 
+6. Deploy the tags. Replays should begin to appear on the home page of the Amplitude app. Ensure that you're looking at the correct project.
 
 ```html title="Session Replay Script for Google Tag Manager" hl_lines="22"
 <script>
@@ -34,7 +35,10 @@ Instrumenting Amplitude Session Replay with Google Tag Manager requires a differ
 
     loadAsync("https://cdn.amplitude.com/libs/plugin-session-replay-browser-@{$ browser.session_replay.plugin.version $}-min.js.gz", 
       function () {
-        window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1})); 
+        var sessionReplayTracking = window.sessionReplay.plugin({sampleRate: 1});
+        window.amplitude.add(sessionReplayTracking).promise.then(function() {
+           console.log("Session Replay plugin loaded");
+      });
     });
 
 </script>


### PR DESCRIPTION
We need the plugin to be added to the window before Amplitude is ready, so that the plugin can check against the Admin UI's sample rate. this change in steps and initialization triggers ensures the plugin is ready in the window

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
